### PR TITLE
Fix routing to have /auth/ prefix

### DIFF
--- a/descope/common.py
+++ b/descope/common.py
@@ -17,8 +17,8 @@ class EndpointsV1:
     signUpAuthMagicLinkPath = "/v1/auth/signup/magiclink"
     verifyMagicLinkAuthPath = "/v1/auth/magiclink/verify"
     publicKeyPath = "/v1/keys"
-    refreshTokenPath = "/v1/refresh"
-    logoutPath = "/v1/logoutall"
+    refreshTokenPath = "/v1/auth/refresh"
+    logoutPath = "/v1/auth/logoutall"
 
 
 class DeliveryMethod(Enum):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -263,13 +263,13 @@ class TestAuthClient(unittest.TestCase):
     def test_compose_refresh_token_url(self):
         self.assertEqual(
             AuthClient._compose_refresh_token_url(),
-            "/v1/refresh",
+            "/v1/auth/refresh",
         )
 
     def test_compose_logout_url(self):
         self.assertEqual(
             AuthClient._compose_logout_url(),
-            "/v1/logoutall",
+            "/v1/auth/logoutall",
         )
 
     def test_logout(self):


### PR DESCRIPTION
Change was just done on onetimeservice

Comply with this PR: 
https://github.com/descope/onetimeservice/pull/102