### PR TITLE
Ensure management key is set before passing calls to management APIs

### DIFF
--- a/descope/descope_client.py
+++ b/descope/descope_client.py
@@ -38,6 +38,10 @@ class DescopeClient:
 
     @property
     def mgmt(self):
+        if not self._auth.management_key:
+            raise AuthException(
+                400, ERROR_TYPE_INVALID_ARGUMENT, "management_key cannot be empty"
+            )
         return self._mgmt
 
     @property

--- a/tests/test_descope_client.py
+++ b/tests/test_descope_client.py
@@ -52,6 +52,10 @@ class TestDescopeClient(unittest.TestCase):
             DescopeClient(project_id="dummy", public_key=self.public_key_str)
         )
 
+    def test_mgmt(self):
+        client = DescopeClient(self.dummy_project_id, self.public_key_dict)
+        self.assertRaises(AuthException, lambda: client.mgmt)
+
     def test_logout(self):
         dummy_refresh_token = ""
         client = DescopeClient(self.dummy_project_id, self.public_key_dict)


### PR DESCRIPTION

## Description
Ensure management key is set before passing calls to management APIs

## Must
- [X] Tests
- [X] Documentation (if applicable)
