### PR TITLE
Add load user and search all users

### DIFF
--- a/descope/management/common.py
+++ b/descope/management/common.py
@@ -8,6 +8,8 @@ class MgmtV1:
     userCreatePath = "/v1/mgmt/user/create"
     userUpdatePath = "/v1/mgmt/user/update"
     userDeletePath = "/v1/mgmt/user/delete"
+    userLoadPath = "/v1/mgmt/user"
+    usersSearchPath = "/v1/mgmt/user/search"
 
     # sso
     ssoConfigurePath = "/v1/mgmt/sso/settings"

--- a/descope/management/user.py
+++ b/descope/management/user.py
@@ -24,7 +24,7 @@ class User:
         display_name: str = None,
         role_names: List[str] = [],
         user_tenants: List[UserTenants] = [],
-    ) -> dict:
+    ) -> None:
         """
         Create a new user. Users can have any number of optional fields, including email, phone number and authorization.
 
@@ -101,6 +101,58 @@ class User:
             {"identifier": identifier},
             pswd=self._auth.management_key,
         )
+
+    def load(
+        self,
+        identifier: str,
+    ) -> dict:
+        """
+        Load an existing user.
+
+        Args:
+        identifier (str): The identifier of the user to be loaded.
+
+        Return value (dict):
+        User information dictionary
+
+        Raise:
+        AuthException: raised if load operation fails
+        """
+        response = self._auth.do_get(
+            MgmtV1.userLoadPath,
+            {"identifier": identifier},
+            pswd=self._auth.management_key,
+        )
+        return response.json()
+
+    def searchAllUsers(
+        self,
+        tenant_ids: List[str] = [],
+        role_names: List[str] = [],
+        limit: int = 0,
+    ) -> dict:
+        """
+        Search all users.
+
+        Args:
+        tenant_ids (List[str]): Optional list of tenant IDs to filter by
+        role_names (List[str]): Optional list of role names to filter by
+        limit (int): Optional limit of the number of users returned. Leave empty for default.
+
+        Return value (dict):
+        Return dict in the format
+             {"users": []}
+        "users" contains a list of all of the found users and their information
+
+        Raise:
+        AuthException: raised if search operation fails
+        """
+        response = self._auth.do_post(
+            MgmtV1.usersSearchPath,
+            {"tenantIds": tenant_ids, "roleNames": role_names, "limit": limit},
+            pswd=self._auth.management_key,
+        )
+        return response.json()
 
     @staticmethod
     def _compose_create_update_body(

--- a/descope/management/user.py
+++ b/descope/management/user.py
@@ -113,6 +113,8 @@ class User:
         identifier (str): The identifier of the user to be loaded.
 
         Return value (dict):
+        Return dict in the format
+             {"user": []}
         User information dictionary
 
         Raise:

--- a/samples/management_user_sample_app.py
+++ b/samples/management_user_sample_app.py
@@ -27,6 +27,23 @@ def main():
             logging.info(f"User creation failed {e}")
 
         try:
+            logging.info("Searching for created user")
+            user_info = descope_client.mgmt.user.load(user_identifier)
+            logging.info(f"Load: found user {user_info}")
+
+        except AuthException as e:
+            logging.info(f"User load failed {e}")
+
+        try:
+            logging.info("Searching all users created user")
+            all_users = descope_client.mgmt.user.searchAllUsers()
+            for user in all_users["users"]:
+                logging.info(f"Search Found user {user}")
+
+        except AuthException as e:
+            logging.info(f"User load failed {e}")
+
+        try:
             logging.info("Updating newly created user")
             # update overrides all fields, must provide the entire entity
             # we mean to update.
@@ -38,7 +55,7 @@ def main():
             logging.info(f"User update failed {e}")
 
         try:
-            logging.info("Deleting newly created tenant")
+            logging.info("Deleting newly created user")
             descope_client.mgmt.user.delete(user_identifier)
 
         except AuthException as e:

--- a/samples/management_user_sample_app.py
+++ b/samples/management_user_sample_app.py
@@ -28,16 +28,18 @@ def main():
 
         try:
             logging.info("Searching for created user")
-            user_info = descope_client.mgmt.user.load(user_identifier)
-            logging.info(f"Load: found user {user_info}")
+            user_resp = descope_client.mgmt.user.load(user_identifier)
+            user = user_resp["user"]
+            logging.info(f"Load: found user {user}")
 
         except AuthException as e:
             logging.info(f"User load failed {e}")
 
         try:
             logging.info("Searching all users created user")
-            all_users = descope_client.mgmt.user.searchAllUsers()
-            for user in all_users["users"]:
+            users_resp = descope_client.mgmt.user.searchAllUsers()
+            users = users_resp["users"]
+            for user in users:
                 logging.info(f"Search Found user {user}")
 
         except AuthException as e:

--- a/tests/management/test_user.py
+++ b/tests/management/test_user.py
@@ -124,10 +124,11 @@ class TestUser(unittest.TestCase):
         with patch("requests.get") as mock_get:
             network_resp = mock.Mock()
             network_resp.ok = True
-            network_resp.json.return_value = json.loads("""{"id": "u1"}""")
+            network_resp.json.return_value = json.loads("""{"user": {"id": "u1"}}""")
             mock_get.return_value = network_resp
             resp = client.mgmt.user.load("valid-id")
-            self.assertEqual(resp["id"], "u1")
+            user = resp["user"]
+            self.assertEqual(user["id"], "u1")
 
     def test_search_all_users(self):
         client = DescopeClient(

--- a/tests/management/test_user.py
+++ b/tests/management/test_user.py
@@ -1,4 +1,6 @@
+import json
 import unittest
+from unittest import mock
 from unittest.mock import patch
 
 from descope import AuthException, DescopeClient, UserTenants
@@ -100,3 +102,61 @@ class TestUser(unittest.TestCase):
         with patch("requests.post") as mock_post:
             mock_post.return_value.ok = True
             self.assertIsNone(client.mgmt.user.delete("t1"))
+
+    def test_load(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flows
+        with patch("requests.get") as mock_get:
+            mock_get.return_value.ok = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.user.load,
+                "valid-id",
+            )
+
+        # Test success flow
+        with patch("requests.get") as mock_get:
+            network_resp = mock.Mock()
+            network_resp.ok = True
+            network_resp.json.return_value = json.loads("""{"id": "u1"}""")
+            mock_get.return_value = network_resp
+            resp = client.mgmt.user.load("valid-id")
+            self.assertEqual(resp["id"], "u1")
+
+    def test_search_all_users(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flows
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.user.searchAllUsers,
+                ["t1, t2"],
+                ["r1", "r2"],
+            )
+
+        # Test success flow
+        with patch("requests.post") as mock_post:
+            network_resp = mock.Mock()
+            network_resp.ok = True
+            network_resp.json.return_value = json.loads(
+                """{"users": [{"id": "u1"}, {"id": "u2"}]}"""
+            )
+            mock_post.return_value = network_resp
+            resp = client.mgmt.user.searchAllUsers(["t1, t2"], ["r1", "r2"])
+            users = resp["users"]
+            self.assertEqual(len(users), 2)
+            self.assertEqual(users[0]["id"], "u1")
+            self.assertEqual(users[1]["id"], "u2")


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/1040

## Related PRs

## Description

Add the ability to load a single user, or search for multiple users with optional tenant and role filters.

## Must

- [X] Tests
- [X] Documentation (if applicable)
