### PR TITLE
Use new mapping endpoint instead of deprecated role mapping

### DIFF
--- a/descope/__init__.py
+++ b/descope/__init__.py
@@ -8,5 +8,5 @@ from descope.common import (
 )
 from descope.descope_client import DescopeClient
 from descope.exceptions import AuthException
-from descope.management.sso_settings import RoleMapping
+from descope.management.sso_settings import AttributeMapping, RoleMapping
 from descope.management.user import UserTenants

--- a/descope/management/common.py
+++ b/descope/management/common.py
@@ -14,4 +14,7 @@ class MgmtV1:
     # sso
     ssoConfigurePath = "/v1/mgmt/sso/settings"
     ssoMetadataPath = "/v1/mgmt/sso/metadata"
+    ssoMappingPath = "/v1/mgmt/sso/mapping"
+
+    # deprecated
     ssoRoleMappingPath = "/v1/mgmt/sso/roles"

--- a/descope/management/sso_settings.py
+++ b/descope/management/sso_settings.py
@@ -5,12 +5,16 @@ from descope.management.common import MgmtV1
 
 
 class RoleMapping:
+    """Map IDP group names to the Descope role name"""
+
     def __init__(self, groups: List[str], role_name: str):
         self.groups = groups
         self.role_name = role_name
 
 
 class AttributeMapping:
+    """Map Descope user attributes to IDP user attributes"""
+
     def __init__(
         self,
         name: str = None,
@@ -95,7 +99,7 @@ class SSOSettings:
         Args:
         tenant_id (str): The tenant ID to be configured
         role_mappings (List[RoleMapping]): A mapping between IDP groups and Descope roles.
-        attribute_mapping: A mapping between IDP user attributes and descope attributes.
+        attribute_mapping (AttributeMapping): A mapping between IDP user attributes and descope attributes.
 
         Raise:
         AuthException: raised if configuration operation fails

--- a/samples/management_sso_sample_app.py
+++ b/samples/management_sso_sample_app.py
@@ -4,12 +4,12 @@ import sys
 
 dir_name = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(dir_name, "../"))
-from descope import (
+from descope import (  # noqa: E402
+    AttributeMapping,
     AuthException,
     DescopeClient,
     RoleMapping,
-    AttributeMapping,
-)  # noqa: E402
+)
 
 logging.basicConfig(level=logging.INFO)
 

--- a/samples/management_sso_sample_app.py
+++ b/samples/management_sso_sample_app.py
@@ -4,7 +4,12 @@ import sys
 
 dir_name = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(dir_name, "../"))
-from descope import AuthException, DescopeClient, RoleMapping  # noqa: E402
+from descope import (
+    AuthException,
+    DescopeClient,
+    RoleMapping,
+    AttributeMapping,
+)  # noqa: E402
 
 logging.basicConfig(level=logging.INFO)
 
@@ -22,7 +27,8 @@ def main():
         entity_id = ""
         idp_cert = ""
         idp_metadata_url = ""
-        role_mappings = [RoleMapping([], "Tenant Admin")]
+        role_mappings = [RoleMapping(["a"], "Tenant Admin")]
+        attribute_mapping = AttributeMapping(name="MyName")
 
         try:
             logging.info("Configure SSO for tenant")
@@ -48,9 +54,10 @@ def main():
 
         try:
             logging.info("Update tenant role mappings")
-            descope_client.mgmt.sso.map_roles(
+            descope_client.mgmt.sso.mapping(
                 tenant_id,
-                role_mappings == role_mappings,
+                role_mappings=role_mappings,
+                attribute_mapping=attribute_mapping,
             )
 
         except AuthException as e:

--- a/tests/management/test_sso_settings.py
+++ b/tests/management/test_sso_settings.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 
-from descope import AuthException, DescopeClient, RoleMapping
+from descope import AttributeMapping, AuthException, DescopeClient, RoleMapping
 
 
 class TestSSOSettings(unittest.TestCase):
@@ -91,6 +91,38 @@ class TestSSOSettings(unittest.TestCase):
                     "https://idp-meta.com",
                 )
             )
+
+    def test_mapping(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flows
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.sso.mapping,
+                "tenant-id",
+                [RoleMapping(["a", "b"], "role")],
+                AttributeMapping(username="UName"),
+            )
+
+        # Test success flow
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = True
+            self.assertIsNone(
+                client.mgmt.sso.mapping(
+                    "tenant-id",
+                    [RoleMapping(["a", "b"], "role")],
+                    AttributeMapping(username="UName"),
+                )
+            )
+
+    # DEPRECATED
 
     def test_role_mapping(self):
         client = DescopeClient(


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/1040

## Related PRs

## Description

Use the new `mapping` endpoint that allows role mapping as  well as user attribute mapping for an SSO IDP.

## Must

- [X] Tests
- [X] Documentation (if applicable)
