### PR TITLE
Add load_by_jwt_subject to management API

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,10 @@ descope_client.mgmt.user.delete("desmond@descope.com")
 user_resp = descope_client.mgmt.user.load("desmond@descope.com")
 user = user_resp["user"]
 
+# If needed, users can be loaded using the JWT subject as well
+user_resp = descope_client.mgmt.user.load_by_jwt_subject("<jwt-subject>")
+user = user_resp["user"]
+
 # Search all users, optionally according to tenant and/or role filter
 users_resp = descope_client.mgmt.user.search_all(tenant_ids=["my-tenant-id"])
 users = users_resp["users"]

--- a/descope/management/user.py
+++ b/descope/management/user.py
@@ -133,6 +133,32 @@ class User:
         )
         return response.json()
 
+    def load_by_jwt_subject(
+        self,
+        jwt_subject: str,
+    ) -> dict:
+        """
+        Load an existing user by JWT subject.
+        The JWT subject can be found on the user's JWT.
+
+        Args:
+        jwt_subject (str): The JWT subject from the user's JWT.
+
+        Return value (dict):
+        Return dict in the format
+             {"user": {}}
+        Containing the loaded user information.
+
+        Raise:
+        AuthException: raised if load operation fails
+        """
+        response = self._auth.do_get(
+            MgmtV1.userLoadPath,
+            {"jwtSubject": jwt_subject},
+            pswd=self._auth.management_key,
+        )
+        return response.json()
+
     def search_all_users(
         self,
         tenant_ids: List[str] = [],


### PR DESCRIPTION
## Description

Add the ability to load a user by JWT subject.

## Must

- [X] Tests
- [X] Documentation (if applicable)
