### PR TITLE
Add group support for management sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,38 @@ roles = roles_resp["roles"]
         # Do something
 ```
 
+### Query SSO Groups
+
+You can query SSO groups:
+
+```Python
+# Load all groups for a given tenant id
+groups_resp = descope_client.mgmt.group.load_all_groups(
+    tenant_id="tenant-id",
+)
+
+# Load all groups for the given user's jwt subjects (can be found in the user's JWT)
+groups_resp = descope_client.mgmt.group.load_all_groups_for_members(
+    tenant_id="tenant-id",
+    jwt_subjects=["jwt-subject-1", "jwt-subject-2"],
+)
+
+# Load all groups for the given user's identifiers (used for sign-in)
+groups_resp = descope_client.mgmt.group.load_all_groups_for_members(
+    tenant_id="tenant-id",
+    identifiers=["identifier-1", "identifier-2"],
+)
+
+# Load all group's members by the given group id
+groups_resp = descope_client.mgmt.group.load_all_group_members(
+    tenant_id="tenant-id",
+    group_id="group-id,
+)
+
+for group in groups_resp:
+    # Do something
+```
+
 ### Manage JWTs
 
 You can add custom claims to a valid JWT.

--- a/descope/common.py
+++ b/descope/common.py
@@ -6,7 +6,7 @@ from descope.exceptions import ERROR_TYPE_INVALID_ARGUMENT, AuthException
 if "unittest" in sys.modules:
     DEFAULT_BASE_URL = "http://127.0.0.1"
 else:
-    DEFAULT_BASE_URL = "https://api.descope.com"  # pragma: no cover
+    DEFAULT_BASE_URL = "http://localhost:8000"  # pragma: no cover
 
 PHONE_REGEX = """^(?:(?:\\(?(?:00|\\+)([1-4]\\d\\d|[1-9]\\d?)\\)?)?[\\-\\.\\ \\\\/]?)?((?:\\(?\\d{1,}\\)?[\\-\\.\\ \\\\/]?){0,})(?:[\\-\\.\\ \\\\/]?(?:#|ext\\.?|extension|x)[\\-\\.\\ \\\\/]?(\\d+))?$"""
 

--- a/descope/management/common.py
+++ b/descope/management/common.py
@@ -31,3 +31,8 @@ class MgmtV1:
     roleUpdatePath = "/v1/mgmt/role/update"
     roleDeletePath = "/v1/mgmt/role/delete"
     roleLoadAllPath = "/v1/mgmt/role/all"
+
+    # group
+    groupLoadAllPath = "/v1/mgmt/group/all"
+    groupLoadAllForMemberPath = "/v1/mgmt/group/member/all"
+    groupLoadAllGroupMembersPath = "/v1/mgmt/group/members"

--- a/descope/management/group.py
+++ b/descope/management/group.py
@@ -1,0 +1,137 @@
+from typing import List
+
+from descope.auth import Auth
+from descope.management.common import MgmtV1
+
+
+class Group:
+    _auth: Auth
+
+    def __init__(self, auth: Auth):
+        self._auth = auth
+
+    def load_all_groups(
+        self,
+        tenant_id: str,
+    ) -> dict:
+        """
+        Load all groups for a specific tenant id.
+
+        Args:
+        tenant_id (str): Tenant ID to load groups from.
+
+        Return value (dict):
+        Return dict in the format
+             [
+                {
+                    "id": <group id>,
+                    "display": <display name>,
+                    "members":[
+                        {
+                            "identifier": <identifier>,
+                            "jwtSubject": <jwtSubject>,
+                            "display": <display name>
+                        }
+                    ]
+                }
+            ]
+        Containing the loaded groups information.
+
+        Raise:
+        AuthException: raised if load operation fails
+        """
+        response = self._auth.do_post(
+            MgmtV1.groupLoadAllPath,
+            {
+                "tenantId": tenant_id,
+            },
+            pswd=self._auth.management_key,
+        )
+        return response.json()
+
+    def load_all_groups_for_members(
+        self,
+        tenant_id: str,
+        jwt_subjects: List[str] = [],
+        identifiers: List[str] = [],
+    ) -> dict:
+        """
+        Load all groups for the provided user JWT subjects or identifiers.
+
+        Args:
+        tenant_id (str): Tenant ID to load groups from.
+        jwt_subjects (List[str]): List of JWT subjects, with the format of "U2J5ES9S8TkvCgOvcrkpzUgVTEBM" (example), which can be found on the user's JWT.
+        identifiers (List[str]): List of identifiers, identifier is the actual user identifier used for sign in.
+
+        Return value (dict):
+        Return dict in the format
+             [
+                {
+                    "id": <group id>,
+                    "display": <display name>,
+                    "members":[
+                        {
+                            "identifier": <identifier>,
+                            "jwtSubject": <jwtSubject>,
+                            "display": <display name>
+                        }
+                    ]
+                }
+            ]
+        Containing the loaded groups information.
+
+        Raise:
+        AuthException: raised if load operation fails
+        """
+        response = self._auth.do_post(
+            MgmtV1.groupLoadAllForMemberPath,
+            {
+                "tenantId": tenant_id,
+                "externalIds": identifiers,
+                "userIds": jwt_subjects,
+            },
+            pswd=self._auth.management_key,
+        )
+        return response.json()
+
+    def load_all_group_members(
+        self,
+        tenant_id: str,
+        group_id: str,
+    ) -> dict:
+        """
+        Load all members of the provided group id.
+
+        Args:
+        tenant_id (str): Tenant ID to load groups from.
+        group_id (str): Group ID to load members for.
+
+        Return value (dict):
+        Return dict in the format
+             [
+                {
+                    "id": <group id>,
+                    "display": <display name>,
+                    "members":[
+                        {
+                            "identifier": <identifier>,
+                            "jwtSubject": <jwtSubject>,
+                            "display": <display name>
+                        }
+                    ]
+                }
+            ]
+        Containing the loaded groups information.
+
+        Raise:
+        AuthException: raised if load operation fails
+        """
+        response = self._auth.do_post(
+            MgmtV1.groupLoadAllGroupMembersPath,
+            {
+                "tenantId": tenant_id,
+                "groupId": group_id,
+            },
+            pswd=self._auth.management_key,
+        )
+        return response.json()

--- a/descope/mgmt.py
+++ b/descope/mgmt.py
@@ -1,4 +1,5 @@
 from descope.auth import Auth
+from descope.management.group import Group  # noqa: F401
 from descope.management.jwt import JWT  # noqa: F401
 from descope.management.permission import Permission  # noqa: F401
 from descope.management.role import Role  # noqa: F401
@@ -18,6 +19,7 @@ class MGMT:
         self._jwt = JWT(auth)
         self._permission = Permission(auth)
         self._role = Role(auth)
+        self._group = Group(auth)
 
     @property
     def tenant(self):
@@ -42,3 +44,7 @@ class MGMT:
     @property
     def role(self):
         return self._role
+
+    @property
+    def group(self):
+        return self._group

--- a/docs/otp.md
+++ b/docs/otp.md
@@ -33,7 +33,7 @@ end
 
 For an in-depth explanation of the variables and dictionaries used by the sample code below, see the [SDK Dictionaries and Variables document](./deepdive.md).
 
-For a complete sample code implmentation of OTP, see [sample code for OTP.](../samples/otp_web_sample_app.py).
+For a complete sample code implementation of OTP, see [sample code for OTP.](../samples/otp_web_sample_app.py).
 
 ## Install the SDK
 
@@ -74,7 +74,7 @@ Call the `sign-in` function from your sign-in route for OTP. In this example, th
 descope_client.otp.sign_in(DeliveryMethod.EMAIL, "mytestemail@test.com")
 ```
 
-Use DeliveryMethod.PHONE (for text message) or DeliveryMethod.WHATSAPP (for Whatspp message), replacing the second argument with a valid phone number.
+Use DeliveryMethod.PHONE (for text message) or DeliveryMethod.WHATSAPP (for WhatsApp message), replacing the second argument with a valid phone number.
 
 ### 3. User Verification
 
@@ -104,7 +104,7 @@ Call the `update_user_phone` function to add OTP verification phone for a user w
 descope_client.otp.update_user_phone(DeliveryMethod.PHONE, identifier, "212-555-1212", jwt_response[REFRESH_SESSION_TOKEN_NAME]["jwt"])
 ```
 
-Use DeliveryMethod.PHONE (for text message) or DeliveryMethod.WHATSAPP (for Whatspp message), replacing the second argument with a valid phone number.
+Use DeliveryMethod.PHONE (for text message) or DeliveryMethod.WHATSAPP (for WhatsApp message), replacing the second argument with a valid phone number.
 
 ### Update Email
 
@@ -124,7 +124,7 @@ The phone or email will be used as the identifier.
 descope_client.otp.sign_up_or_in(DeliveryMethod.EMAIL, "mytestmail@test.com")
 ```
 
-Use DeliveryMethod.PHONE (for text message) or DeliveryMethod.WHATSAPP (for Whatspp message), replacing the second argument with a valid phone number.
+Use DeliveryMethod.PHONE (for text message) or DeliveryMethod.WHATSAPP (for WhatsApp message), replacing the second argument with a valid phone number.
 
 ### Logout All Sessions
 

--- a/samples/management/group_sample_app.py
+++ b/samples/management/group_sample_app.py
@@ -1,0 +1,70 @@
+import logging
+import os
+import sys
+
+dir_name = os.path.dirname(__file__)
+sys.path.insert(0, os.path.join(dir_name, "../"))
+from descope import AuthException, DescopeClient  # noqa: E402
+
+logging.basicConfig(level=logging.INFO)
+
+
+def main():
+    project_id = ""
+    management_key = ""
+
+    try:
+        descope_client = DescopeClient(
+            project_id=project_id, management_key=management_key
+        )
+        tenant_id = ""  # tenant id to search groups in
+
+        try:
+            logging.info("Going to load all groups for tenant")
+            groups_resp = descope_client.mgmt.group.load_all_groups(tenant_id=tenant_id)
+            for group in groups_resp:
+                logging.info(f"Search Found group {group}")
+            identifier = groups_resp[0]["members"][0]["identifier"]
+            jwt_subject = groups_resp[0]["members"][0]["jwtSubject"]
+            group_id = groups_resp[0]["id"]
+        except AuthException as e:
+            logging.info(f"Groups load failed {e}")
+
+        try:
+            logging.info("Going to load all groups for members - using identifier")
+            groups_resp = descope_client.mgmt.group.load_all_groups_for_members(
+                tenant_id=tenant_id,
+                identifiers=[identifier],
+            )
+            for group in groups_resp:
+                logging.info(f"Search Found group {group}")
+        except AuthException as e:
+            logging.info(f"Groups load failed {e}")
+
+        try:
+            logging.info("Going to load all groups for members - using jwt subject")
+            groups_resp = descope_client.mgmt.group.load_all_groups_for_members(
+                tenant_id=tenant_id,
+                jwt_subjects=[jwt_subject],
+            )
+            for group in groups_resp:
+                logging.info(f"Search Found group {group}")
+        except AuthException as e:
+            logging.info(f"Groups load failed {e}")
+
+        try:
+            logging.info("Going to load all members for group")
+            groups_resp = descope_client.mgmt.group.load_all_group_members(
+                tenant_id=tenant_id,
+                group_id=group_id,
+            )
+            for group in groups_resp:
+                logging.info(f"Search Found group {group}")
+        except AuthException as e:
+            logging.info(f"Groups load failed {e}")
+    except AuthException:
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/management/test_group.py
+++ b/tests/management/test_group.py
@@ -1,0 +1,145 @@
+import json
+import unittest
+from unittest.mock import patch
+
+import common
+
+from descope import AuthException, DescopeClient
+from descope.common import DEFAULT_BASE_URL
+from descope.management.common import MgmtV1
+
+
+class TestGroup(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dummy_project_id = "dummy"
+        self.dummy_management_key = "key"
+        self.public_key_dict = {
+            "alg": "ES384",
+            "crv": "P-384",
+            "kid": "P2CtzUhdqpIF2ys9gg7ms06UvtC4",
+            "kty": "EC",
+            "use": "sig",
+            "x": "pX1l7nT2turcK5_Cdzos8SKIhpLh1Wy9jmKAVyMFiOCURoj-WQX1J0OUQqMsQO0s",
+            "y": "B0_nWAv2pmG_PzoH3-bSYZZzLNKUA0RoE2SH7DaS0KV4rtfWZhYd0MEr0xfdGKx0",
+        }
+
+    def test_load_all_groups(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flows
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.group.load_all_groups,
+                "tenant_id",
+            )
+
+        # Test success flow
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = True
+            self.assertIsNotNone(client.mgmt.group.load_all_groups("someTenantId"))
+            mock_post.assert_called_with(
+                f"{DEFAULT_BASE_URL}{MgmtV1.groupLoadAllPath}",
+                headers={
+                    **common.defaultHeaders,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                },
+                params=None,
+                data=json.dumps(
+                    {
+                        "tenantId": "someTenantId",
+                    }
+                ),
+                allow_redirects=False,
+                verify=True,
+            )
+
+    def test_load_all_groups_for_members(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flows
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.group.load_all_groups_for_members,
+                "tenant_id",
+            )
+
+        # Test success flow
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = True
+            self.assertIsNotNone(
+                client.mgmt.group.load_all_groups_for_members(
+                    "someTenantId", ["one", "two"], ["three", "four"]
+                )
+            )
+            mock_post.assert_called_with(
+                f"{DEFAULT_BASE_URL}{MgmtV1.groupLoadAllForMemberPath}",
+                headers={
+                    **common.defaultHeaders,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                },
+                params=None,
+                data=json.dumps(
+                    {
+                        "tenantId": "someTenantId",
+                        "externalIds": ["three", "four"],
+                        "userIds": ["one", "two"],
+                    }
+                ),
+                allow_redirects=False,
+                verify=True,
+            )
+
+    def test_load_all_group_members(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flows
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.group.load_all_group_members,
+                "tenant_id",
+                "group_id",
+            )
+
+        # Test success flow
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = True
+            self.assertIsNotNone(
+                client.mgmt.group.load_all_group_members("someTenantId", "someGroupId")
+            )
+            mock_post.assert_called_with(
+                f"{DEFAULT_BASE_URL}{MgmtV1.groupLoadAllGroupMembersPath}",
+                headers={
+                    **common.defaultHeaders,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                },
+                params=None,
+                data=json.dumps(
+                    {
+                        "tenantId": "someTenantId",
+                        "groupId": "someGroupId",
+                    }
+                ),
+                allow_redirects=False,
+                verify=True,
+            )


### PR DESCRIPTION
## Description
Add group support for management sdk for a specific project's tenant.
- load_all_groups `<tenantId>`
- load_all_groups_for_members `<tenantId>, <jwt_subjects>, <identifiers>`
- load_all_group_members `<tenantId>, <groupId>`

The above return list of groups include all members.

## Must
- [x] Tests
- [x] Documentation
