### PR TITLE
Access keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ descope_client.mgmt.user.create(
     email="desmond@descope.com",
     display_name="Desmond Copeland",
     user_tenants=[
-        UserTenant("my-tenant-id", ["role-name1"]),
+        AssociatedTenant("my-tenant-id", ["role-name1"]),
     ],
 )
 
@@ -371,7 +371,7 @@ descope_client.mgmt.user.update(
     email="desmond@descope.com",
     display_name="Desmond Copeland",
     user_tenants=[
-        UserTenant("my-tenant-id", ["role-name1", "role-name2"]),
+        AssociatedTenant("my-tenant-id", ["role-name1", "role-name2"]),
     ],
 )
 

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ descope_client.mgmt.user.update(
     ],
 )
 
-# Tenant deletion cannot be undone. Use carefully.
+# User deletion cannot be undone. Use carefully.
 descope_client.mgmt.user.delete("desmond@descope.com")
 
 # Load specific user
@@ -391,6 +391,50 @@ users_resp = descope_client.mgmt.user.search_all(tenant_ids=["my-tenant-id"])
 users = users_resp["users"]
     for user in users:
         # Do something
+```
+
+### Manage Access Keys
+
+You can create, update, delete or load access keys, as well as search according to filters:
+
+```Python
+# An access key must have a name and expiration, other fields are optional.
+# Roles should be set directly if no tenants exist, otherwise set
+# on a per-tenant basis.
+create_resp = descope_client.mgmt.access_key.create(
+    name="name",
+    expired_time=1677844931,
+    key_tenants=[
+        AssociatedTenant("my-tenant-id", ["role-name1"]),
+    ],
+)
+key = create_resp["key"]
+hash = create_resp["hash"] # make sure to save the returned hash securely. It will not be returned again.
+
+# Load a specific access key
+access_key_resp = descope_client.mgmt.access_key.load("key-id")
+access_key = access_key_resp["key"]
+
+# Search all access keys, optionally according to a tenant filter
+keys_resp = descope_client.mgmt.access_key.search_all(tenant_ids=["my-tenant-id"])
+keys = keys_resp["keys"]
+    for key in keys:
+        # Do something
+
+# Update will override all fields as is. Use carefully.
+descope_client.mgmt.access_key.update(
+    id="key-id",
+    name="new name",
+)
+
+# Access keys can be deactivated to prevent usage. This can be undone using "activate".
+descope_client.mgmt.access_key.deactivate("key-id")
+
+# Disabled access keys can be activated once again.
+descope_client.mgmt.access_key.activate("key-id")
+
+# Access key deletion cannot be undone. Use carefully.
+descope_client.mgmt.access_key.delete("key-id")
 ```
 
 ### Manage SSO Setting

--- a/descope/__init__.py
+++ b/descope/__init__.py
@@ -8,5 +8,5 @@ from descope.common import (
 )
 from descope.descope_client import DescopeClient
 from descope.exceptions import AuthException
+from descope.management.common import AssociatedTenant
 from descope.management.sso_settings import AttributeMapping, RoleMapping
-from descope.management.user import UserTenant

--- a/descope/management/access_key.py
+++ b/descope/management/access_key.py
@@ -1,0 +1,197 @@
+from typing import List
+
+from descope.auth import Auth
+from descope.management.common import (
+    AssociatedTenant,
+    MgmtV1,
+    associated_tenants_to_dict,
+)
+
+
+class AccessKey:
+    _auth: Auth
+
+    def __init__(self, auth: Auth):
+        self._auth = auth
+
+    def create(
+        self,
+        name: str,
+        expire_time: int = 0,
+        role_names: List[str] = [],
+        key_tenants: List[AssociatedTenant] = [],
+    ) -> dict:
+        """
+        Create a new access key.
+
+        Args:
+        name (str): Access key name.
+        expire_time (int): Access key expiration. Leave at 0 to make it indefinite.
+        role_names (List[str]): An optional list of the access key's roles without tenant association. These roles are
+            mutually exclusive with the `key_tenant` roles, which take precedence over them.
+        key_tenants (List[AssociatedTenant]): An optional list of the access key's tenants, and optionally, their roles per tenant. These roles are
+            mutually exclusive with the general `role_names`, and take precedence over them.
+
+        Return value (dict):
+        Return dict in the format
+            {
+                "key": {},
+                "hash": {}
+            }
+        Containing the created access key information and its hash. The key hash will only be returned on creation.
+        Make sure to save it securely.
+
+        Raise:
+        AuthException: raised if create operation fails
+        """
+        response = self._auth.do_post(
+            MgmtV1.accessKeyCreatePath,
+            AccessKey._compose_create_body(name, expire_time, role_names, key_tenants),
+            pswd=self._auth.management_key,
+        )
+        return response.json()
+
+    def load(
+        self,
+        id: str,
+    ) -> dict:
+        """
+        Load an existing access key.
+
+        Args:
+        id (str): The id of the access key to be loaded.
+
+        Return value (dict):
+        Return dict in the format
+             {"key": {}}
+        Containing the loaded access key information.
+
+        Raise:
+        AuthException: raised if load operation fails
+        """
+        response = self._auth.do_get(
+            MgmtV1.accessKeyLoadPath,
+            {"id": id},
+            pswd=self._auth.management_key,
+        )
+        return response.json()
+
+    def search_all_access_keys(
+        self,
+        tenant_ids: List[str] = [],
+    ) -> dict:
+        """
+        Search all access keys.
+
+        Args:
+        tenant_ids (List[str]): Optional list of tenant IDs to filter by
+
+        Return value (dict):
+        Return dict in the format
+             {"keys": []}
+        "keys" contains a list of all of the found users and their information
+
+        Raise:
+        AuthException: raised if search operation fails
+        """
+        response = self._auth.do_post(
+            MgmtV1.accessKeysSearchPath,
+            {"tenantIds": tenant_ids},
+            pswd=self._auth.management_key,
+        )
+        return response.json()
+
+    def update(
+        self,
+        id: str,
+        name: str,
+    ):
+        """
+        Update an existing access key with the given various fields. IMPORTANT: All parameters are used as overrides
+        to the existing access key. Empty fields will override populated fields. Use carefully.
+
+        Args:
+        id (str): The id of the access key to update.
+        name (str): The updated access key name.
+
+        Raise:
+        AuthException: raised if update operation fails
+        """
+        self._auth.do_post(
+            MgmtV1.accessKeyUpdatePath,
+            {"id": id, "name": name},
+            pswd=self._auth.management_key,
+        )
+
+    def deactivate(
+        self,
+        id: str,
+    ):
+        """
+        Deactivate an existing access key. IMPORTANT: This deactivated key will not be usable from this stage.
+        It will, however, persist, and can be activated again if needed.
+
+        Args:
+        id (str): The id of the access key to be deactivated.
+
+        Raise:
+        AuthException: raised if deactivation operation fails
+        """
+        self._auth.do_post(
+            MgmtV1.accessKeyDeactivatePath,
+            {"id": id},
+            pswd=self._auth.management_key,
+        )
+
+    def activate(
+        self,
+        id: str,
+    ):
+        """
+        Activate an existing access key. IMPORTANT: Only deactivated keys can be activated again,
+        and become usable once more. New access keys are active by default.
+
+        Args:
+        id (str): The id of the access key to be activate.
+
+        Raise:
+        AuthException: raised if activation operation fails
+        """
+        self._auth.do_post(
+            MgmtV1.accessKeyActivatePath,
+            {"id": id},
+            pswd=self._auth.management_key,
+        )
+
+    def delete(
+        self,
+        id: str,
+    ):
+        """
+        Delete an existing access key. IMPORTANT: This action is irreversible. Use carefully.
+
+        Args:
+        id (str): The id of the access key to be deleted.
+
+        Raise:
+        AuthException: raised if creation operation fails
+        """
+        self._auth.do_post(
+            MgmtV1.accessKeyDeletePath,
+            {"id": id},
+            pswd=self._auth.management_key,
+        )
+
+    @staticmethod
+    def _compose_create_body(
+        name: str,
+        expire_time: int,
+        role_names: List[str],
+        key_tenants: List[AssociatedTenant],
+    ) -> dict:
+        return {
+            "name": name,
+            "expireTime": expire_time,
+            "roleNames": role_names,
+            "keyTenants": associated_tenants_to_dict(key_tenants),
+        }

--- a/descope/management/common.py
+++ b/descope/management/common.py
@@ -15,6 +15,15 @@ class MgmtV1:
     userLoadPath = "/v1/mgmt/user"
     usersSearchPath = "/v1/mgmt/user/search"
 
+    # access key
+    accessKeyCreatePath = "/v1/mgmt/accesskey/create"
+    accessKeyLoadPath = "/v1/mgmt/accesskey"
+    accessKeysSearchPath = "/v1/mgmt/accesskey/search"
+    accessKeyUpdatePath = "/v1/mgmt/accesskey/update"
+    accessKeyDeactivatePath = "/v1/mgmt/accesskey/deactivate"
+    accessKeyActivatePath = "/v1/mgmt/accesskey/activate"
+    accessKeyDeletePath = "/v1/mgmt/accesskey/delete"
+
     # sso
     ssoConfigurePath = "/v1/mgmt/sso/settings"
     ssoMetadataPath = "/v1/mgmt/sso/metadata"

--- a/descope/management/common.py
+++ b/descope/management/common.py
@@ -1,3 +1,6 @@
+from typing import List
+
+
 class MgmtV1:
     # tenant
     tenantCreatePath = "/v1/mgmt/tenant/create"
@@ -36,3 +39,28 @@ class MgmtV1:
     groupLoadAllPath = "/v1/mgmt/group/all"
     groupLoadAllForMemberPath = "/v1/mgmt/group/member/all"
     groupLoadAllGroupMembersPath = "/v1/mgmt/group/members"
+
+
+class AssociatedTenant:
+    """
+    Represents a tenant association for a User or Access Key. The tenant_id is required to denote
+    which tenant the user or access key belongs to. The role_names array is an optional list of
+    roles for the user or access key in this specific tenant.
+    """
+
+    def __init__(self, tenant_id: str, role_names: List[str] = []):
+        self.tenant_id = tenant_id
+        self.role_names = role_names
+
+
+def associated_tenants_to_dict(associated_tenants: List[AssociatedTenant]) -> list:
+    associated_tenant_list = []
+    if associated_tenants:
+        for associated_tenant in associated_tenants:
+            associated_tenant_list.append(
+                {
+                    "tenantId": associated_tenant.tenant_id,
+                    "roleNames": associated_tenant.role_names,
+                }
+            )
+    return associated_tenant_list

--- a/descope/management/user.py
+++ b/descope/management/user.py
@@ -1,13 +1,11 @@
 from typing import List
 
 from descope.auth import Auth
-from descope.management.common import MgmtV1
-
-
-class UserTenant:
-    def __init__(self, tenant_id: str, role_names: List[str] = []):
-        self.tenant_id = tenant_id
-        self.role_names = role_names
+from descope.management.common import (
+    AssociatedTenant,
+    MgmtV1,
+    associated_tenants_to_dict,
+)
 
 
 class User:
@@ -23,7 +21,7 @@ class User:
         phone_number: str = None,
         display_name: str = None,
         role_names: List[str] = [],
-        user_tenants: List[UserTenant] = [],
+        user_tenants: List[AssociatedTenant] = [],
     ) -> dict:
         """
         Create a new user. Users can have any number of optional fields, including email, phone number and authorization.
@@ -35,7 +33,7 @@ class User:
         display_name (str): Optional user display name.
         role_names (List[str]): An optional list of the user's roles without tenant association. These roles are
             mutually exclusive with the `user_tenant` roles, which take precedence over them.
-        user_tenants (List[UserTenants]): An optional list of the user's tenants, and optionally, their roles per tenant. These roles are
+        user_tenants (List[AssociatedTenant]): An optional list of the user's tenants, and optionally, their roles per tenant. These roles are
             mutually exclusive with the general `role_names`, and take precedence over them.
 
         Return value (dict):
@@ -62,7 +60,7 @@ class User:
         phone_number: str = None,
         display_name: str = None,
         role_names: List[str] = [],
-        user_tenants: List[UserTenant] = [],
+        user_tenants: List[AssociatedTenant] = [],
     ):
         """
         Update an existing user with the given various fields. IMPORTANT: All parameters are used as overrides
@@ -75,7 +73,7 @@ class User:
         display_name (str): Optional user display name.
         role_names (List[str]): An optional list of the user's roles without tenant association. These roles are
             mutually exclusive with the `user_tenant` roles, which take precedence over the general roles.
-        user_tenants (List[UserTenants]): An optional list of the user's tenants, and optionally, their roles per tenant. These roles are
+        user_tenants (List[AssociatedTenant]): An optional list of the user's tenants, and optionally, their roles per tenant. These roles are
             mutually exclusive with the general `role_names`, and take precedence over them.
 
         Raise:
@@ -195,7 +193,7 @@ class User:
         phone_number: str,
         display_name: str,
         role_names: List[str],
-        user_tenants: List[UserTenant],
+        user_tenants: List[AssociatedTenant],
     ) -> dict:
         return {
             "identifier": identifier,
@@ -203,18 +201,5 @@ class User:
             "phoneNumber": phone_number,
             "displayName": display_name,
             "roleNames": role_names,
-            "userTenants": User._user_tenants_to_dict(user_tenants),
+            "userTenants": associated_tenants_to_dict(user_tenants),
         }
-
-    @staticmethod
-    def _user_tenants_to_dict(user_tenants: List[UserTenant]) -> list:
-        user_tenant_list = []
-        if user_tenants:
-            for user_tenant in user_tenants:
-                user_tenant_list.append(
-                    {
-                        "tenantId": user_tenant.tenant_id,
-                        "roleNames": user_tenant.role_names,
-                    }
-                )
-        return user_tenant_list

--- a/descope/management/user.py
+++ b/descope/management/user.py
@@ -157,7 +157,7 @@ class User:
         )
         return response.json()
 
-    def search_all_users(
+    def search_all(
         self,
         tenant_ids: List[str] = [],
         role_names: List[str] = [],

--- a/descope/mgmt.py
+++ b/descope/mgmt.py
@@ -1,4 +1,5 @@
 from descope.auth import Auth
+from descope.management.access_key import AccessKey  # noqa: F401
 from descope.management.group import Group  # noqa: F401
 from descope.management.jwt import JWT  # noqa: F401
 from descope.management.permission import Permission  # noqa: F401
@@ -15,6 +16,7 @@ class MGMT:
         self._auth = auth
         self._tenant = Tenant(auth)
         self._user = User(auth)
+        self._access_key = AccessKey(auth)
         self._sso = SSOSettings(auth)
         self._jwt = JWT(auth)
         self._permission = Permission(auth)
@@ -28,6 +30,10 @@ class MGMT:
     @property
     def user(self):
         return self._user
+
+    @property
+    def access_key(self):
+        return self._access_key
 
     @property
     def sso(self):

--- a/samples/management/access_key_sample_app.py
+++ b/samples/management/access_key_sample_app.py
@@ -1,0 +1,88 @@
+import logging
+import os
+import sys
+
+dir_name = os.path.dirname(__file__)
+sys.path.insert(0, os.path.join(dir_name, "../"))
+from descope import AuthException, DescopeClient  # noqa: E402
+
+logging.basicConfig(level=logging.INFO)
+
+
+def main():
+    project_id = ""
+    management_key = ""
+
+    try:
+        descope_client = DescopeClient(
+            project_id=project_id, management_key=management_key
+        )
+        key_id = ""
+
+        try:
+            logging.info("Going to create a new access key")
+            access_key_resp = descope_client.mgmt.access_key.create(
+                name="key-name", expire_time=1677844931
+            )
+            access_key = access_key_resp["key"]
+            key_id = access_key["id"]
+            logging.info(f"Create: created access key {access_key}")
+
+        except AuthException as e:
+            logging.info(f"Access key creation failed {e}")
+
+        try:
+            logging.info("Searching for created access key")
+            access_key_resp = descope_client.mgmt.access_key.load(key_id)
+            access_key = access_key_resp["key"]
+            logging.info(f"Load: found access key {access_key}")
+
+        except AuthException as e:
+            logging.info(f"Access key load failed {e}")
+
+        try:
+            logging.info("Searching all access keys")
+            users_resp = descope_client.mgmt.access_key.search_all_access_keys()
+            access_keys = users_resp["keys"]
+            for key in access_keys:
+                logging.info(f"Search Found access key {key}")
+
+        except AuthException as e:
+            logging.info(f"Access key load failed {e}")
+
+        try:
+            logging.info("Updating newly created access key")
+            # update overrides all fields, must provide the entire entity
+            # we mean to update.
+            descope_client.mgmt.access_key.update(key_id, "New key name")
+
+        except AuthException as e:
+            logging.info(f"Access key update failed {e}")
+
+        try:
+            logging.info("Deactivating newly created access key")
+            descope_client.mgmt.access_key.deactivate(key_id)
+
+        except AuthException as e:
+            logging.info(f"Access key deactivate failed {e}")
+
+        try:
+            logging.info("Activating newly created access key")
+            descope_client.mgmt.access_key.activate(key_id)
+
+        except AuthException as e:
+            logging.info(f"Access key activate failed {e}")
+
+        try:
+            logging.info("Deleting newly created access key")
+            descope_client.mgmt.access_key.delete(key_id)
+
+        except AuthException as e:
+            logging.info(f"Access key deletion failed {e}")
+
+    except AuthException:
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/management/user_sample_app.py
+++ b/samples/management/user_sample_app.py
@@ -37,7 +37,7 @@ def main():
 
         try:
             logging.info("Searching all users created user")
-            users_resp = descope_client.mgmt.user.search_all_users()
+            users_resp = descope_client.mgmt.user.search_all()
             users = users_resp["users"]
             for user in users:
                 logging.info(f"Search Found user {user}")

--- a/tests/management/test_access_key.py
+++ b/tests/management/test_access_key.py
@@ -1,0 +1,320 @@
+import json
+import unittest
+from unittest import mock
+from unittest.mock import patch
+
+import common
+
+from descope import AssociatedTenant, AuthException, DescopeClient
+from descope.common import DEFAULT_BASE_URL
+from descope.management.common import MgmtV1
+
+
+class TestAccessKey(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dummy_project_id = "dummy"
+        self.dummy_management_key = "key"
+        self.public_key_dict = {
+            "alg": "ES384",
+            "crv": "P-384",
+            "kid": "P2CtzUhdqpIF2ys9gg7ms06UvtC4",
+            "kty": "EC",
+            "use": "sig",
+            "x": "pX1l7nT2turcK5_Cdzos8SKIhpLh1Wy9jmKAVyMFiOCURoj-WQX1J0OUQqMsQO0s",
+            "y": "B0_nWAv2pmG_PzoH3-bSYZZzLNKUA0RoE2SH7DaS0KV4rtfWZhYd0MEr0xfdGKx0",
+        }
+
+    def test_create(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flows
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.access_key.create,
+                "key-name",
+            )
+
+        # Test success flow
+        with patch("requests.post") as mock_post:
+            network_resp = mock.Mock()
+            network_resp.ok = True
+            network_resp.json.return_value = json.loads(
+                """{"key": {"id": "ak1"}, "hash": "abc"}"""
+            )
+            mock_post.return_value = network_resp
+            resp = client.mgmt.access_key.create(
+                name="key-name",
+                expire_time=123456789,
+                key_tenants=[
+                    AssociatedTenant("tenant1"),
+                    AssociatedTenant("tenant2", ["role1", "role2"]),
+                ],
+            )
+            accessKey = resp["key"]
+            self.assertEqual(accessKey["id"], "ak1")
+            mock_post.assert_called_with(
+                f"{DEFAULT_BASE_URL}{MgmtV1.accessKeyCreatePath}",
+                headers={
+                    **common.defaultHeaders,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                },
+                params=None,
+                data=json.dumps(
+                    {
+                        "name": "key-name",
+                        "expireTime": 123456789,
+                        "roleNames": [],
+                        "keyTenants": [
+                            {"tenantId": "tenant1", "roleNames": []},
+                            {"tenantId": "tenant2", "roleNames": ["role1", "role2"]},
+                        ],
+                    }
+                ),
+                allow_redirects=False,
+                verify=True,
+            )
+
+    def test_load(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flows
+        with patch("requests.get") as mock_get:
+            mock_get.return_value.ok = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.access_key.load,
+                "key-id",
+            )
+
+        # Test success flow
+        with patch("requests.get") as mock_get:
+            network_resp = mock.Mock()
+            network_resp.ok = True
+            network_resp.json.return_value = json.loads("""{"key": {"id": "ak1"}}""")
+            mock_get.return_value = network_resp
+            resp = client.mgmt.access_key.load("key-id")
+            accessKey = resp["key"]
+            self.assertEqual(accessKey["id"], "ak1")
+            mock_get.assert_called_with(
+                f"{DEFAULT_BASE_URL}{MgmtV1.accessKeyLoadPath}",
+                headers={
+                    **common.defaultHeaders,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                },
+                params={"id": "key-id"},
+                allow_redirects=None,
+                verify=True,
+            )
+
+    def test_search_all_users(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flows
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.access_key.search_all_access_keys,
+                ["t1, t2"],
+            )
+
+        # Test success flow
+        with patch("requests.post") as mock_post:
+            network_resp = mock.Mock()
+            network_resp.ok = True
+            network_resp.json.return_value = json.loads(
+                """{"keys": [{"id": "ak1"}, {"id": "ak2"}]}"""
+            )
+            mock_post.return_value = network_resp
+            resp = client.mgmt.access_key.search_all_access_keys(["t1, t2"])
+            keys = resp["keys"]
+            self.assertEqual(len(keys), 2)
+            self.assertEqual(keys[0]["id"], "ak1")
+            self.assertEqual(keys[1]["id"], "ak2")
+            mock_post.assert_called_with(
+                f"{DEFAULT_BASE_URL}{MgmtV1.accessKeysSearchPath}",
+                headers={
+                    **common.defaultHeaders,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                },
+                params=None,
+                data=json.dumps(
+                    {
+                        "tenantIds": ["t1, t2"],
+                    }
+                ),
+                allow_redirects=False,
+                verify=True,
+            )
+
+    def test_update(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flows
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.access_key.update,
+                "key-id",
+                "new-name",
+            )
+
+        # Test success flow
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = True
+            self.assertIsNone(
+                client.mgmt.access_key.update(
+                    "key-id",
+                    name="new-name",
+                )
+            )
+            mock_post.assert_called_with(
+                f"{DEFAULT_BASE_URL}{MgmtV1.accessKeyUpdatePath}",
+                headers={
+                    **common.defaultHeaders,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                },
+                params=None,
+                data=json.dumps(
+                    {
+                        "id": "key-id",
+                        "name": "new-name",
+                    }
+                ),
+                allow_redirects=False,
+                verify=True,
+            )
+
+    def test_deactivate(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flows
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.access_key.deactivate,
+                "key-id",
+            )
+
+        # Test success flow
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = True
+            self.assertIsNone(client.mgmt.access_key.deactivate("ak1"))
+            mock_post.assert_called_with(
+                f"{DEFAULT_BASE_URL}{MgmtV1.accessKeyDeactivatePath}",
+                headers={
+                    **common.defaultHeaders,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                },
+                params=None,
+                data=json.dumps(
+                    {
+                        "id": "ak1",
+                    }
+                ),
+                allow_redirects=False,
+                verify=True,
+            )
+
+    def test_activate(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flows
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.access_key.activate,
+                "key-id",
+            )
+
+        # Test success flow
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = True
+            self.assertIsNone(client.mgmt.access_key.activate("ak1"))
+            mock_post.assert_called_with(
+                f"{DEFAULT_BASE_URL}{MgmtV1.accessKeyActivatePath}",
+                headers={
+                    **common.defaultHeaders,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                },
+                params=None,
+                data=json.dumps(
+                    {
+                        "id": "ak1",
+                    }
+                ),
+                allow_redirects=False,
+                verify=True,
+            )
+
+    def test_delete(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flows
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.access_key.delete,
+                "key-id",
+            )
+
+        # Test success flow
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = True
+            self.assertIsNone(client.mgmt.access_key.delete("ak1"))
+            mock_post.assert_called_with(
+                f"{DEFAULT_BASE_URL}{MgmtV1.accessKeyDeletePath}",
+                headers={
+                    **common.defaultHeaders,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                },
+                params=None,
+                data=json.dumps(
+                    {
+                        "id": "ak1",
+                    }
+                ),
+                allow_redirects=False,
+                verify=True,
+            )

--- a/tests/management/test_user.py
+++ b/tests/management/test_user.py
@@ -242,7 +242,7 @@ class TestUser(unittest.TestCase):
                 verify=True,
             )
 
-    def test_search_all_users(self):
+    def test_search_all(self):
         client = DescopeClient(
             self.dummy_project_id,
             self.public_key_dict,
@@ -255,7 +255,7 @@ class TestUser(unittest.TestCase):
             mock_post.return_value.ok = False
             self.assertRaises(
                 AuthException,
-                client.mgmt.user.search_all_users,
+                client.mgmt.user.search_all,
                 ["t1, t2"],
                 ["r1", "r2"],
             )
@@ -268,7 +268,7 @@ class TestUser(unittest.TestCase):
                 """{"users": [{"id": "u1"}, {"id": "u2"}]}"""
             )
             mock_post.return_value = network_resp
-            resp = client.mgmt.user.search_all_users(["t1, t2"], ["r1", "r2"])
+            resp = client.mgmt.user.search_all(["t1, t2"], ["r1", "r2"])
             users = resp["users"]
             self.assertEqual(len(users), 2)
             self.assertEqual(users[0]["id"], "u1")

--- a/tests/management/test_user.py
+++ b/tests/management/test_user.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import common
 
-from descope import AuthException, DescopeClient, UserTenant
+from descope import AssociatedTenant, AuthException, DescopeClient
 from descope.common import DEFAULT_BASE_URL
 from descope.management.common import MgmtV1
 
@@ -52,8 +52,8 @@ class TestUser(unittest.TestCase):
                 email="name@mail.com",
                 display_name="Name",
                 user_tenants=[
-                    UserTenant("tenant1"),
-                    UserTenant("tenant2", ["role1", "role2"]),
+                    AssociatedTenant("tenant1"),
+                    AssociatedTenant("tenant2", ["role1", "role2"]),
                 ],
             )
             user = resp["user"]


### PR DESCRIPTION
## Description
Add the ability to manage access keys. Some breaking changes introduced in the form of renaming. See the section below for details. All examples and README updated accordingly.

## Breaking Changes
- Rename `UserTenant` -> `AssociatedTenant` and moved it to `common.py`
  - It is used by both users and access keys

## Must
- [X] Tests
- [X] Documentation (if applicable)