### PR TITLE
fix otp signin function to use refresh pramater as the right argument to do_post

### DIFF
--- a/descope/authmethod/otp.py
+++ b/descope/authmethod/otp.py
@@ -46,7 +46,7 @@ class OTP:
 
         uri = OTP._compose_signin_url(method)
         body = OTP._compose_signin_body(login_id, login_options)
-        self._auth.do_post(uri, body, refresh_token)
+        self._auth.do_post(uri, body, None, refresh_token)
 
     def sign_up(self, method: DeliveryMethod, login_id: str, user: dict = None) -> None:
         """

--- a/poetry.lock
+++ b/poetry.lock
@@ -1185,14 +1185,14 @@ watchdog = ["watchdog"]
 
 [[package]]
 name = "zipp"
-version = "3.12.1"
+version = "3.13.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "zipp-3.12.1-py3-none-any.whl", hash = "sha256:6c4fe274b8f85ec73c37a8e4e3fa00df9fb9335da96fb789e3b96b318e5097b3"},
-    {file = "zipp-3.12.1.tar.gz", hash = "sha256:a3cac813d40993596b39ea9e93a18e8a2076d5c378b8bc88ec32ab264e04ad02"},
+    {file = "zipp-3.13.0-py3-none-any.whl", hash = "sha256:e8b2a36ea17df80ffe9e2c4fda3f693c3dad6df1697d3cd3af232db680950b0b"},
+    {file = "zipp-3.13.0.tar.gz", hash = "sha256:23f70e964bc11a34cef175bc90ba2914e1e4545ea1e3e2f67c079671883f9cb6"},
 ]
 
 [package.extras]

--- a/tests/test_enchantedlink.py
+++ b/tests/test_enchantedlink.py
@@ -124,6 +124,37 @@ class TestEnchantedLink(unittest.TestCase):
             self.assertEqual(res["pendingRef"], "aaaa")
             self.assertEqual(res["linkId"], "24")
 
+        # Validate refresh token used while provided
+        with patch("requests.post") as mock_post:
+            refresh_token = "dummy refresh token"
+            enchantedlink.sign_in(
+                "dummy@dummy.com",
+                "http://test.me",
+                LoginOptions(stepup=True),
+                refresh_token=refresh_token,
+            )
+            mock_post.assert_called_with(
+                f"{DEFAULT_BASE_URL}{EndpointsV1.signInAuthEnchantedLinkPath}/email",
+                headers={
+                    **common.defaultHeaders,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{refresh_token}",
+                },
+                params=None,
+                data=json.dumps(
+                    {
+                        "loginId": "dummy@dummy.com",
+                        "URI": "http://test.me",
+                        "loginOptions": {
+                            "stepup": True,
+                            "customClaims": None,
+                            "mfa": False,
+                        },
+                    }
+                ),
+                allow_redirects=False,
+                verify=True,
+            )
+
     def test_sign_in_with_login_options(self):
         enchantedlink = EnchantedLink(Auth(self.dummy_project_id, self.public_key_dict))
         with patch("requests.post") as mock_post:

--- a/tests/test_magiclink.py
+++ b/tests/test_magiclink.py
@@ -138,6 +138,38 @@ class TestMagicLink(unittest.TestCase):
                 LoginOptions(mfa=True),
             )
 
+        # Validate refresh token used while provided
+        with patch("requests.post") as mock_post:
+            refresh_token = "dummy refresh token"
+            magiclink.sign_in(
+                DeliveryMethod.EMAIL,
+                "dummy@dummy.com",
+                "http://test.me",
+                LoginOptions(stepup=True),
+                refresh_token=refresh_token,
+            )
+            mock_post.assert_called_with(
+                f"{DEFAULT_BASE_URL}{EndpointsV1.signInAuthMagicLinkPath}/email",
+                headers={
+                    **common.defaultHeaders,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{refresh_token}",
+                },
+                params=None,
+                data=json.dumps(
+                    {
+                        "loginId": "dummy@dummy.com",
+                        "URI": "http://test.me",
+                        "loginOptions": {
+                            "stepup": True,
+                            "customClaims": None,
+                            "mfa": False,
+                        },
+                    }
+                ),
+                allow_redirects=False,
+                verify=True,
+            )
+
     def test_sign_up(self):
         signup_user_details = {
             "username": "jhon",

--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -255,6 +255,36 @@ class TestOTP(unittest.TestCase):
                 LoginOptions(mfa=True),
             )
 
+        # Validate refresh token used while provided
+        with patch("requests.post") as mock_post:
+            refresh_token = "dummy refresh token"
+            client.otp.sign_in(
+                DeliveryMethod.EMAIL,
+                "dummy@dummy.com",
+                LoginOptions(stepup=True),
+                refresh_token=refresh_token,
+            )
+            mock_post.assert_called_with(
+                f"{DEFAULT_BASE_URL}{EndpointsV1.signInAuthOTPPath}/email",
+                headers={
+                    **common.defaultHeaders,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{refresh_token}",
+                },
+                params=None,
+                data=json.dumps(
+                    {
+                        "loginId": "dummy@dummy.com",
+                        "loginOptions": {
+                            "stepup": True,
+                            "customClaims": None,
+                            "mfa": False,
+                        },
+                    }
+                ),
+                allow_redirects=False,
+                verify=True,
+            )
+
     def test_sign_up_or_in(self):
         client = DescopeClient(self.dummy_project_id, self.public_key_dict)
 

--- a/tests/test_totp.py
+++ b/tests/test_totp.py
@@ -97,6 +97,45 @@ class TestTOTP(unittest.TestCase):
                 LoginOptions(mfa=True),
             )
 
+        # Validate refresh token used while provided
+        with patch("requests.post") as mock_post:
+            my_mock_response = mock.Mock()
+            my_mock_response.ok = True
+            my_mock_response.cookies = {}
+            data = json.loads(
+                """{"jwts": ["eyJhbGciOiJFUzM4NCIsImtpZCI6IjJCdDVXTGNjTFVleTFEcDd1dHB0WmIzRng5SyIsInR5cCI6IkpXVCJ9.eyJjb29raWVEb21haW4iOiIiLCJjb29raWVFeHBpcmF0aW9uIjoxNjYwMzg4MDc4LCJjb29raWVNYXhBZ2UiOjI1OTE5OTksImNvb2tpZU5hbWUiOiJEU1IiLCJjb29raWVQYXRoIjoiLyIsImV4cCI6MTY2MDIxNTI3OCwiaWF0IjoxNjU3Nzk2MDc4LCJpc3MiOiIyQnQ1V0xjY0xVZXkxRHA3dXRwdFpiM0Z4OUsiLCJzdWIiOiIyQnRFSGtnT3UwMmxtTXh6UElleGRNdFV3MU0ifQ.oAnvJ7MJvCyL_33oM7YCF12JlQ0m6HWRuteUVAdaswfnD4rHEBmPeuVHGljN6UvOP4_Cf0559o39UHVgm3Fwb-q7zlBbsu_nP1-PRl-F8NJjvBgC5RsAYabtJq7LlQmh"], "user": {"loginIds": ["guyp@descope.com"], "name": "", "email": "guyp@descope.com", "phone": "", "verifiedEmail": true, "verifiedPhone": false}, "firstSeen": false}"""
+            )
+            my_mock_response.json.return_value = data
+            mock_post.return_value = my_mock_response
+            refresh_token = "dummy refresh token"
+            totp.sign_in_code(
+                "dummy@dummy.com",
+                "1234",
+                LoginOptions(stepup=True),
+                refresh_token=refresh_token,
+            )
+            mock_post.assert_called_with(
+                f"{DEFAULT_BASE_URL}{EndpointsV1.verifyTOTPPath}",
+                headers={
+                    **common.defaultHeaders,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{refresh_token}",
+                },
+                params=None,
+                data=json.dumps(
+                    {
+                        "loginId": "dummy@dummy.com",
+                        "code": "1234",
+                        "loginOptions": {
+                            "stepup": True,
+                            "customClaims": None,
+                            "mfa": False,
+                        },
+                    }
+                ),
+                allow_redirects=False,
+                verify=True,
+            )
+
     def test_update_user(self):
         totp = TOTP(Auth(self.dummy_project_id, self.public_key_dict))
 


### PR DESCRIPTION
Fix OTP sign in function so it will forward the refresh_token parameter to do_post function in the right place.
Added tests for all missing auth methods to validate refresh token used (if provided) and forward on the right place.