### PR TITLE
Add page to search users

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ user_resp = descope_client.mgmt.user.load_by_user_id("<user-id>")
 user = user_resp["user"]
 
 # Search all users, optionally according to tenant and/or role filter
+# results can be paginated using the limit and page parameters
 users_resp = descope_client.mgmt.user.search_all(tenant_ids=["my-tenant-id"])
 users = users_resp["users"]
     for user in users:

--- a/descope/management/user.py
+++ b/descope/management/user.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from descope.auth import Auth
+from descope.exceptions import ERROR_TYPE_INVALID_ARGUMENT, AuthException
 from descope.management.common import (
     AssociatedTenant,
     MgmtV1,
@@ -162,6 +163,7 @@ class User:
         tenant_ids: List[str] = [],
         role_names: List[str] = [],
         limit: int = 0,
+        page: int = 0,
     ) -> dict:
         """
         Search all users.
@@ -170,6 +172,7 @@ class User:
         tenant_ids (List[str]): Optional list of tenant IDs to filter by
         role_names (List[str]): Optional list of role names to filter by
         limit (int): Optional limit of the number of users returned. Leave empty for default.
+        page (int): Optional pagination control. Pages start at 0 and must be non-negative.
 
         Return value (dict):
         Return dict in the format
@@ -179,9 +182,24 @@ class User:
         Raise:
         AuthException: raised if search operation fails
         """
+        if limit < 0:
+            raise AuthException(
+                400, ERROR_TYPE_INVALID_ARGUMENT, "limit must be non-negative"
+            )
+
+        if page < 0:
+            raise AuthException(
+                400, ERROR_TYPE_INVALID_ARGUMENT, "page must be non-negative"
+            )
+
         response = self._auth.do_post(
             MgmtV1.usersSearchPath,
-            {"tenantIds": tenant_ids, "roleNames": role_names, "limit": limit},
+            {
+                "tenantIds": tenant_ids,
+                "roleNames": role_names,
+                "limit": limit,
+                "page": page,
+            },
             pswd=self._auth.management_key,
         )
         return response.json()

--- a/tests/management/test_user.py
+++ b/tests/management/test_user.py
@@ -224,6 +224,16 @@ class TestUser(unittest.TestCase):
                 ["r1", "r2"],
             )
 
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = True
+            self.assertRaises(
+                AuthException, self.client.mgmt.user.search_all, [], [], -1, 0
+            )
+
+            self.assertRaises(
+                AuthException, self.client.mgmt.user.search_all, [], [], 0, -1
+            )
+
         # Test success flow
         with patch("requests.post") as mock_post:
             network_resp = mock.Mock()
@@ -249,6 +259,7 @@ class TestUser(unittest.TestCase):
                         "tenantIds": ["t1, t2"],
                         "roleNames": ["r1", "r2"],
                         "limit": 0,
+                        "page": 0,
                     }
                 ),
                 allow_redirects=False,


### PR DESCRIPTION
## Description

Add the ability to paginate the search user response. If not explicitly set, `page` defaults to `0` (the first page).

## Must

- [X] Tests
- [X] Documentation (if applicable)
