### PR TITLE
Align to pep8 naming convention

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 per-file-ignores = __init__.py:F401
-ignore = E501
+ignore = E501,N818

--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ for group in groups_resp:
 You can add custom claims to a valid JWT.
 
 ```python
-updated_jwt = client.mgmt.jwt.updateJWT(
+updated_jwt = client.mgmt.jwt.update_jwt(
     jwt: "original-jwt",
     custom_claims: {
         "custom-key1": "custom-value1",

--- a/descope/auth.py
+++ b/descope/auth.py
@@ -150,9 +150,9 @@ class Auth:
 
     @staticmethod
     def verify_delivery_method(
-        method: DeliveryMethod, loginId: str, user: dict
+        method: DeliveryMethod, login_id: str, user: dict
     ) -> bool:
-        if not loginId:
+        if not login_id:
             return False
 
         if not isinstance(user, dict):
@@ -160,7 +160,7 @@ class Auth:
 
         if method == DeliveryMethod.EMAIL:
             if not user.get("email", None):
-                user["email"] = loginId
+                user["email"] = login_id
             try:
                 validate_email(email=user["email"], check_deliverability=False)
                 return True
@@ -168,12 +168,12 @@ class Auth:
                 return False
         elif method == DeliveryMethod.SMS:
             if not user.get("phone", None):
-                user["phone"] = loginId
+                user["phone"] = login_id
             if not re.match(PHONE_REGEX, user["phone"]):
                 return False
         elif method == DeliveryMethod.WHATSAPP:
             if not user.get("phone", None):
-                user["phone"] = loginId
+                user["phone"] = login_id
             if not re.match(PHONE_REGEX, user["phone"]):
                 return False
         else:
@@ -249,7 +249,7 @@ class Auth:
             )
 
     def exchange_access_key(self, access_key: str) -> dict:
-        uri = EndpointsV1.exchangeAuthAccessKeyPath
+        uri = EndpointsV1.exchange_auth_access_key_path
         server_response = self.do_post(uri, {}, None, access_key)
         json = server_response.json()
         return self._generate_auth_info(json, None, False)
@@ -312,7 +312,7 @@ class Auth:
 
         # This function called under mutex protection so no need to acquire it once again
         response = requests.get(
-            f"{self.base_url}{EndpointsV2.publicKeyPath}/{self.project_id}",
+            f"{self.base_url}{EndpointsV2.public_key_path}/{self.project_id}",
             headers=self._get_default_headers(),
             verify=self.secure,
         )
@@ -328,8 +328,8 @@ class Auth:
 
         jwks_data = response.text
         try:
-            jwkeysWrapper = json.loads(jwks_data)
-            jwkeys = jwkeysWrapper["keys"]
+            jwkeys_wrapper = json.loads(jwks_data)
+            jwkeys = jwkeys_wrapper["keys"]
         except Exception as e:
             raise AuthException(
                 500, ERROR_TYPE_INVALID_PUBLIC_KEY, f"Unable to load jwks. Error: {e}"
@@ -534,7 +534,7 @@ class Auth:
                 401, ERROR_TYPE_INVALID_TOKEN, f"Invalid refresh token: {e}"
             )
 
-        uri = EndpointsV1.refreshTokenPath
+        uri = EndpointsV1.refresh_token_path
         response = self.do_post(uri, {}, None, refresh_token)
 
         resp = response.json()

--- a/descope/authmethod/enchantedlink.py
+++ b/descope/authmethod/enchantedlink.py
@@ -8,7 +8,7 @@ from descope.common import (
     DeliveryMethod,
     EndpointsV1,
     LoginOptions,
-    validateRefreshTokenProvided,
+    validate_refresh_token_provided,
 )
 from descope.exceptions import ERROR_TYPE_INVALID_ARGUMENT, AuthException
 
@@ -33,7 +33,7 @@ class EnchantedLink:
                 "login_id is empty",
             )
 
-        validateRefreshTokenProvided(login_options, refresh_token)
+        validate_refresh_token_provided(login_options, refresh_token)
 
         body = EnchantedLink._compose_signin_body(login_id, uri, login_options)
         uri = EnchantedLink._compose_signin_url()
@@ -64,7 +64,7 @@ class EnchantedLink:
         return EnchantedLink._get_pending_ref_from_response(response)
 
     def get_session(self, pending_ref: str) -> dict:
-        uri = EndpointsV1.getSessionEnchantedLinkAuthPath
+        uri = EndpointsV1.get_session_enchantedlink_auth_path
         body = EnchantedLink._compose_get_session_body(pending_ref)
         response = self._auth.do_post(uri, body, None)
 
@@ -75,7 +75,7 @@ class EnchantedLink:
         return jwt_response
 
     def verify(self, token: str):
-        uri = EndpointsV1.verifyEnchantedLinkAuthPath
+        uri = EndpointsV1.verify_enchantedlink_auth_path
         body = EnchantedLink._compose_verify_body(token)
         self._auth.do_post(uri, body, None)
 
@@ -88,26 +88,26 @@ class EnchantedLink:
         Auth.validate_email(email)
 
         body = EnchantedLink._compose_update_user_email_body(login_id, email)
-        uri = EndpointsV1.updateUserEmailOTPPath
+        uri = EndpointsV1.update_user_email_otp_path
         response = self._auth.do_post(uri, body, None, refresh_token)
         return EnchantedLink._get_pending_ref_from_response(response)
 
     @staticmethod
     def _compose_signin_url() -> str:
         return Auth.compose_url(
-            EndpointsV1.signInAuthEnchantedLinkPath, DeliveryMethod.EMAIL
+            EndpointsV1.sign_in_auth_enchantedlink_path, DeliveryMethod.EMAIL
         )
 
     @staticmethod
     def _compose_signup_url() -> str:
         return Auth.compose_url(
-            EndpointsV1.signUpAuthEnchantedLinkPath, DeliveryMethod.EMAIL
+            EndpointsV1.sign_up_auth_enchantedlink_path, DeliveryMethod.EMAIL
         )
 
     @staticmethod
     def _compose_sign_up_or_in_url() -> str:
         return Auth.compose_url(
-            EndpointsV1.signUpOrInAuthEnchantedLinkPath, DeliveryMethod.EMAIL
+            EndpointsV1.sign_up_or_in_auth_enchantedlink_path, DeliveryMethod.EMAIL
         )
 
     @staticmethod

--- a/descope/authmethod/magiclink.py
+++ b/descope/authmethod/magiclink.py
@@ -6,7 +6,7 @@ from descope.common import (
     DeliveryMethod,
     EndpointsV1,
     LoginOptions,
-    validateRefreshTokenProvided,
+    validate_refresh_token_provided,
 )
 from descope.exceptions import ERROR_TYPE_INVALID_ARGUMENT, AuthException
 
@@ -32,7 +32,7 @@ class MagicLink:
                 "Identifier is empty",
             )
 
-        validateRefreshTokenProvided(login_options, refresh_token)
+        validate_refresh_token_provided(login_options, refresh_token)
 
         body = MagicLink._compose_signin_body(login_id, uri, login_options)
         uri = MagicLink._compose_signin_url(method)
@@ -63,7 +63,7 @@ class MagicLink:
         self._auth.do_post(uri, body, None)
 
     def verify(self, token: str) -> dict:
-        uri = EndpointsV1.verifyMagicLinkAuthPath
+        uri = EndpointsV1.verify_magiclink_auth_path
         body = MagicLink._compose_verify_body(token)
         response = self._auth.do_post(uri, body, None)
         resp = response.json()
@@ -81,7 +81,7 @@ class MagicLink:
         Auth.validate_email(email)
 
         body = MagicLink._compose_update_user_email_body(login_id, email)
-        uri = EndpointsV1.updateUserEmailOTPPath
+        uri = EndpointsV1.update_user_email_otp_path
         self._auth.do_post(uri, body, None, refresh_token)
 
     def update_user_phone(
@@ -95,24 +95,24 @@ class MagicLink:
         Auth.validate_phone(method, phone)
 
         body = MagicLink._compose_update_user_phone_body(login_id, phone)
-        uri = EndpointsV1.updateUserPhoneOTPPath
+        uri = EndpointsV1.update_user_phone_otp_path
         self._auth.do_post(uri, body, None, refresh_token)
 
     @staticmethod
     def _compose_signin_url(method: DeliveryMethod) -> str:
-        return Auth.compose_url(EndpointsV1.signInAuthMagicLinkPath, method)
+        return Auth.compose_url(EndpointsV1.sign_in_auth_magiclink_path, method)
 
     @staticmethod
     def _compose_signup_url(method: DeliveryMethod) -> str:
-        return Auth.compose_url(EndpointsV1.signUpAuthMagicLinkPath, method)
+        return Auth.compose_url(EndpointsV1.sign_up_auth_magiclink_path, method)
 
     @staticmethod
     def _compose_sign_up_or_in_url(method: DeliveryMethod) -> str:
-        return Auth.compose_url(EndpointsV1.signUpOrInAuthMagicLinkPath, method)
+        return Auth.compose_url(EndpointsV1.sign_up_or_in_auth_magiclink_path, method)
 
     @staticmethod
     def _compose_update_phone_url(method: DeliveryMethod) -> str:
-        return Auth.compose_url(EndpointsV1.updateUserPhoneMagicLinkPath, method)
+        return Auth.compose_url(EndpointsV1.update_user_phone_magiclink_path, method)
 
     @staticmethod
     def _compose_signin_body(

--- a/descope/authmethod/oauth.py
+++ b/descope/authmethod/oauth.py
@@ -1,5 +1,5 @@
 from descope.auth import Auth
-from descope.common import EndpointsV1, LoginOptions, validateRefreshTokenProvided
+from descope.common import EndpointsV1, LoginOptions, validate_refresh_token_provided
 from descope.exceptions import ERROR_TYPE_INVALID_ARGUMENT, AuthException
 
 
@@ -24,9 +24,9 @@ class OAuth:
                 f"Unknown OAuth provider: {provider}",
             )
 
-        validateRefreshTokenProvided(login_options, refresh_token)
+        validate_refresh_token_provided(login_options, refresh_token)
 
-        uri = EndpointsV1.oauthStart
+        uri = EndpointsV1.oauth_start_path
         params = OAuth._compose_start_params(provider, return_url)
         response = self._auth.do_post(
             uri, login_options.__dict__ if login_options else {}, params, refresh_token
@@ -35,7 +35,7 @@ class OAuth:
         return response.json()
 
     def exchange_token(self, code: str) -> dict:
-        uri = EndpointsV1.oauthExchangeTokenPath
+        uri = EndpointsV1.oauth_exchange_token_path
         return self._auth.exchange_token(uri, code)
 
     @staticmethod
@@ -45,8 +45,8 @@ class OAuth:
         return True
 
     @staticmethod
-    def _compose_start_params(provider: str, returnURL: str) -> dict:
+    def _compose_start_params(provider: str, return_url: str) -> dict:
         res = {"provider": provider}
-        if returnURL:
-            res["redirectURL"] = returnURL
+        if return_url:
+            res["redirectURL"] = return_url
         return res

--- a/descope/authmethod/otp.py
+++ b/descope/authmethod/otp.py
@@ -4,7 +4,7 @@ from descope.common import (
     DeliveryMethod,
     EndpointsV1,
     LoginOptions,
-    validateRefreshTokenProvided,
+    validate_refresh_token_provided,
 )
 from descope.exceptions import ERROR_TYPE_INVALID_ARGUMENT, AuthException
 
@@ -42,7 +42,7 @@ class OTP:
                 400, ERROR_TYPE_INVALID_ARGUMENT, "Identifier cannot be empty"
             )
 
-        validateRefreshTokenProvided(login_options, refresh_token)
+        validate_refresh_token_provided(login_options, refresh_token)
 
         uri = OTP._compose_signin_url(method)
         body = OTP._compose_signin_body(login_id, login_options)
@@ -154,7 +154,7 @@ class OTP:
 
         Auth.validate_email(email)
 
-        uri = EndpointsV1.updateUserEmailOTPPath
+        uri = EndpointsV1.update_user_email_otp_path
         body = OTP._compose_update_user_email_body(login_id, email)
         self._auth.do_post(uri, body, None, refresh_token)
 
@@ -187,23 +187,23 @@ class OTP:
 
     @staticmethod
     def _compose_signup_url(method: DeliveryMethod) -> str:
-        return Auth.compose_url(EndpointsV1.signUpAuthOTPPath, method)
+        return Auth.compose_url(EndpointsV1.sign_up_auth_otp_path, method)
 
     @staticmethod
     def _compose_signin_url(method: DeliveryMethod) -> str:
-        return Auth.compose_url(EndpointsV1.signInAuthOTPPath, method)
+        return Auth.compose_url(EndpointsV1.sign_in_auth_otp_path, method)
 
     @staticmethod
     def _compose_sign_up_or_in_url(method: DeliveryMethod) -> str:
-        return Auth.compose_url(EndpointsV1.signUpOrInAuthOTPPath, method)
+        return Auth.compose_url(EndpointsV1.sign_up_or_in_auth_otp_path, method)
 
     @staticmethod
     def _compose_verify_code_url(method: DeliveryMethod) -> str:
-        return Auth.compose_url(EndpointsV1.verifyCodeAuthPath, method)
+        return Auth.compose_url(EndpointsV1.verify_code_auth_path, method)
 
     @staticmethod
     def _compose_update_phone_url(method: DeliveryMethod) -> str:
-        return Auth.compose_url(EndpointsV1.updateUserPhoneOTPPath, method)
+        return Auth.compose_url(EndpointsV1.update_user_phone_otp_path, method)
 
     @staticmethod
     def _compose_signup_body(method: DeliveryMethod, login_id: str, user: dict) -> dict:

--- a/descope/authmethod/saml.py
+++ b/descope/authmethod/saml.py
@@ -1,5 +1,5 @@
 from descope.auth import Auth
-from descope.common import EndpointsV1, LoginOptions, validateRefreshTokenProvided
+from descope.common import EndpointsV1, LoginOptions, validate_refresh_token_provided
 from descope.exceptions import ERROR_TYPE_INVALID_ARGUMENT, AuthException
 
 
@@ -29,9 +29,9 @@ class SAML:
                 400, ERROR_TYPE_INVALID_ARGUMENT, "Return url cannot be empty"
             )
 
-        validateRefreshTokenProvided(login_options, refresh_token)
+        validate_refresh_token_provided(login_options, refresh_token)
 
-        uri = EndpointsV1.authSAMLStart
+        uri = EndpointsV1.auth_saml_start_path
         params = SAML._compose_start_params(tenant, return_url)
         response = self._auth.do_post(
             uri, login_options.__dict__ if login_options else {}, params, refresh_token
@@ -40,7 +40,7 @@ class SAML:
         return response.json()
 
     def exchange_token(self, code: str) -> dict:
-        uri = EndpointsV1.samlExchangeTokenPath
+        uri = EndpointsV1.saml_exchange_token_path
         return self._auth.exchange_token(uri, code)
 
     @staticmethod

--- a/descope/authmethod/totp.py
+++ b/descope/authmethod/totp.py
@@ -3,7 +3,7 @@ from descope.common import (
     REFRESH_SESSION_COOKIE_NAME,
     EndpointsV1,
     LoginOptions,
-    validateRefreshTokenProvided,
+    validate_refresh_token_provided,
 )
 from descope.exceptions import ERROR_TYPE_INVALID_ARGUMENT, AuthException
 
@@ -40,7 +40,7 @@ class TOTP:
                 400, ERROR_TYPE_INVALID_ARGUMENT, "Identifier cannot be empty"
             )
 
-        uri = EndpointsV1.signUpAuthTOTPPath
+        uri = EndpointsV1.sign_up_auth_totp_path
         body = TOTP._compose_signup_body(login_id, user)
         response = self._auth.do_post(uri, body)
 
@@ -81,9 +81,9 @@ class TOTP:
                 400, ERROR_TYPE_INVALID_ARGUMENT, "Code cannot be empty"
             )
 
-        validateRefreshTokenProvided(login_options, refresh_token)
+        validate_refresh_token_provided(login_options, refresh_token)
 
-        uri = EndpointsV1.verifyTOTPPath
+        uri = EndpointsV1.verify_totp_path
         body = TOTP._compose_signin_body(login_id, code, login_options)
         response = self._auth.do_post(uri, body, None, refresh_token)
 
@@ -122,7 +122,7 @@ class TOTP:
                 400, ERROR_TYPE_INVALID_ARGUMENT, "Refresh token cannot be empty"
             )
 
-        uri = EndpointsV1.updateTOTPPath
+        uri = EndpointsV1.update_totp_path
         body = TOTP._compose_update_user_body(login_id)
         response = self._auth.do_post(uri, body, None, refresh_token)
 

--- a/descope/authmethod/webauthn.py
+++ b/descope/authmethod/webauthn.py
@@ -3,7 +3,7 @@ from descope.common import (
     REFRESH_SESSION_COOKIE_NAME,
     EndpointsV1,
     LoginOptions,
-    validateRefreshTokenProvided,
+    validate_refresh_token_provided,
 )
 from descope.exceptions import ERROR_TYPE_INVALID_ARGUMENT, AuthException
 
@@ -31,17 +31,17 @@ class WebAuthn:
         if not user:
             user = {}
 
-        uri = EndpointsV1.signUpAuthWebauthnStart
+        uri = EndpointsV1.sign_up_auth_webauthn_start_path
         body = WebAuthn._compose_sign_up_start_body(login_id, user, origin)
         response = self._auth.do_post(uri, body)
 
         return response.json()
 
-    def sign_up_finish(self, transactionID: str, response: str) -> dict:
+    def sign_up_finish(self, transaction_id: str, response: str) -> dict:
         """
         Docs
         """
-        if not transactionID:
+        if not transaction_id:
             raise AuthException(
                 400, ERROR_TYPE_INVALID_ARGUMENT, "Transaction id cannot be empty"
             )
@@ -51,8 +51,8 @@ class WebAuthn:
                 400, ERROR_TYPE_INVALID_ARGUMENT, "Response cannot be empty"
             )
 
-        uri = EndpointsV1.signUpAuthWebauthnFinish
-        body = WebAuthn._compose_sign_up_in_finish_body(transactionID, response)
+        uri = EndpointsV1.sign_up_auth_webauthn_finish_path
+        body = WebAuthn._compose_sign_up_in_finish_body(transaction_id, response)
         response = self._auth.do_post(uri, body, None, "")
 
         resp = response.json()
@@ -81,9 +81,9 @@ class WebAuthn:
                 400, ERROR_TYPE_INVALID_ARGUMENT, "Origin cannot be empty"
             )
 
-        validateRefreshTokenProvided(login_options, refresh_token)
+        validate_refresh_token_provided(login_options, refresh_token)
 
-        uri = EndpointsV1.signInAuthWebauthnStart
+        uri = EndpointsV1.sign_in_auth_webauthn_start_path
         body = WebAuthn._compose_sign_in_start_body(login_id, origin, login_options)
         response = self._auth.do_post(uri, body, pswd=refresh_token)
 
@@ -103,7 +103,7 @@ class WebAuthn:
                 400, ERROR_TYPE_INVALID_ARGUMENT, "Response cannot be empty"
             )
 
-        uri = EndpointsV1.signInAuthWebauthnFinish
+        uri = EndpointsV1.sign_in_auth_webauthn_finish_path
         body = WebAuthn._compose_sign_up_in_finish_body(transaction_id, response)
         response = self._auth.do_post(uri, body, None)
 
@@ -131,7 +131,7 @@ class WebAuthn:
                 400, ERROR_TYPE_INVALID_ARGUMENT, "Origin cannot be empty"
             )
 
-        uri = EndpointsV1.signUpOrInAuthWebauthnStart
+        uri = EndpointsV1.sign_up_or_in_auth_webauthn_start_path
         body = WebAuthn._compose_sign_up_or_in_start_body(login_id, origin)
         response = self._auth.do_post(uri, body)
 
@@ -151,7 +151,7 @@ class WebAuthn:
                 400, ERROR_TYPE_INVALID_ARGUMENT, "Refresh token cannot be empty"
             )
 
-        uri = EndpointsV1.updateAuthWebauthnStart
+        uri = EndpointsV1.update_auth_webauthn_start_path
         body = WebAuthn._compose_update_start_body(login_id, origin)
         response = self._auth.do_post(uri, body, None, refresh_token)
 
@@ -171,7 +171,7 @@ class WebAuthn:
                 400, ERROR_TYPE_INVALID_ARGUMENT, "Response cannot be empty"
             )
 
-        uri = EndpointsV1.updateAuthWebauthnFinish
+        uri = EndpointsV1.update_auth_webauthn_finish_path
         body = WebAuthn._compose_update_finish_body(transaction_id, response)
         self._auth.do_post(uri, body)
 

--- a/descope/common.py
+++ b/descope/common.py
@@ -21,64 +21,64 @@ REDIRECT_LOCATION_COOKIE_NAME = "Location"
 
 
 class EndpointsV1:
-    refreshTokenPath = "/v1/auth/refresh"
-    logoutPath = "/v1/auth/logout"
-    logoutAllPath = "/v1/auth/logoutall"
-    mePath = "/v1/auth/me"
+    refresh_token_path = "/v1/auth/refresh"
+    logout_path = "/v1/auth/logout"
+    logout_all_path = "/v1/auth/logoutall"
+    me_path = "/v1/auth/me"
 
     # accesskey
-    exchangeAuthAccessKeyPath = "/v1/auth/accesskey/exchange"
+    exchange_auth_access_key_path = "/v1/auth/accesskey/exchange"
 
     # otp
-    signUpAuthOTPPath = "/v1/auth/otp/signup"
-    signInAuthOTPPath = "/v1/auth/otp/signin"
-    signUpOrInAuthOTPPath = "/v1/auth/otp/signup-in"
-    verifyCodeAuthPath = "/v1/auth/otp/verify"
-    updateUserEmailOTPPath = "/v1/auth/otp/update/email"
-    updateUserPhoneOTPPath = "/v1/auth/otp/update/phone"
+    sign_up_auth_otp_path = "/v1/auth/otp/signup"
+    sign_in_auth_otp_path = "/v1/auth/otp/signin"
+    sign_up_or_in_auth_otp_path = "/v1/auth/otp/signup-in"
+    verify_code_auth_path = "/v1/auth/otp/verify"
+    update_user_email_otp_path = "/v1/auth/otp/update/email"
+    update_user_phone_otp_path = "/v1/auth/otp/update/phone"
 
     # magiclink
-    signUpAuthMagicLinkPath = "/v1/auth/magiclink/signup"
-    signInAuthMagicLinkPath = "/v1/auth/magiclink/signin"
-    signUpOrInAuthMagicLinkPath = "/v1/auth/magiclink/signup-in"
-    verifyMagicLinkAuthPath = "/v1/auth/magiclink/verify"
-    getSessionMagicLinkAuthPath = "/v1/auth/magiclink/pending-session"
-    updateUserEmailMagicLinkPath = "/v1/auth/magiclink/update/email"
-    updateUserPhoneMagicLinkPath = "/v1/auth/magiclink/update/phone"
+    sign_up_auth_magiclink_path = "/v1/auth/magiclink/signup"
+    sign_in_auth_magiclink_path = "/v1/auth/magiclink/signin"
+    sign_up_or_in_auth_magiclink_path = "/v1/auth/magiclink/signup-in"
+    verify_magiclink_auth_path = "/v1/auth/magiclink/verify"
+    get_session_magiclink_auth_path = "/v1/auth/magiclink/pending-session"
+    update_user_email_magiclink_path = "/v1/auth/magiclink/update/email"
+    update_user_phone_magiclink_path = "/v1/auth/magiclink/update/phone"
 
     # enchantedlink
-    signUpAuthEnchantedLinkPath = "/v1/auth/enchantedlink/signup"
-    signInAuthEnchantedLinkPath = "/v1/auth/enchantedlink/signin"
-    signUpOrInAuthEnchantedLinkPath = "/v1/auth/enchantedlink/signup-in"
-    verifyEnchantedLinkAuthPath = "/v1/auth/enchantedlink/verify"
-    getSessionEnchantedLinkAuthPath = "/v1/auth/enchantedlink/pending-session"
-    updateUserEmailEnchantedLinkPath = "/v1/auth/enchantedlink/update/email"
+    sign_up_auth_enchantedlink_path = "/v1/auth/enchantedlink/signup"
+    sign_in_auth_enchantedlink_path = "/v1/auth/enchantedlink/signin"
+    sign_up_or_in_auth_enchantedlink_path = "/v1/auth/enchantedlink/signup-in"
+    verify_enchantedlink_auth_path = "/v1/auth/enchantedlink/verify"
+    get_session_enchantedlink_auth_path = "/v1/auth/enchantedlink/pending-session"
+    update_user_email_enchantedlink_path = "/v1/auth/enchantedlink/update/email"
 
     # oauth
-    oauthStart = "/v1/auth/oauth/authorize"
-    oauthExchangeTokenPath = "/v1/auth/oauth/exchange"
+    oauth_start_path = "/v1/auth/oauth/authorize"
+    oauth_exchange_token_path = "/v1/auth/oauth/exchange"
 
     # saml
-    authSAMLStart = "/v1/auth/saml/authorize"
-    samlExchangeTokenPath = "/v1/auth/saml/exchange"
+    auth_saml_start_path = "/v1/auth/saml/authorize"
+    saml_exchange_token_path = "/v1/auth/saml/exchange"
 
     # totp
-    signUpAuthTOTPPath = "/v1/auth/totp/signup"
-    verifyTOTPPath = "/v1/auth/totp/verify"
-    updateTOTPPath = "/v1/auth/totp/update"
+    sign_up_auth_totp_path = "/v1/auth/totp/signup"
+    verify_totp_path = "/v1/auth/totp/verify"
+    update_totp_path = "/v1/auth/totp/update"
 
     # webauthn
-    signUpAuthWebauthnStart = "/v1/auth/webauthn/signup/start"
-    signUpAuthWebauthnFinish = "/v1/auth/webauthn/signup/finish"
-    signInAuthWebauthnStart = "/v1/auth/webauthn/signin/start"
-    signInAuthWebauthnFinish = "/v1/auth/webauthn/signin/finish"
-    signUpOrInAuthWebauthnStart = "/v1/auth/webauthn/signup-in/start"
-    updateAuthWebauthnStart = "/v1/auth/webauthn/update/start"
-    updateAuthWebauthnFinish = "/v1/auth/webauthn/update/finish"
+    sign_up_auth_webauthn_start_path = "/v1/auth/webauthn/signup/start"
+    sign_up_auth_webauthn_finish_path = "/v1/auth/webauthn/signup/finish"
+    sign_in_auth_webauthn_start_path = "/v1/auth/webauthn/signin/start"
+    sign_in_auth_webauthn_finish_path = "/v1/auth/webauthn/signin/finish"
+    sign_up_or_in_auth_webauthn_start_path = "/v1/auth/webauthn/signup-in/start"
+    update_auth_webauthn_start_path = "/v1/auth/webauthn/update/start"
+    update_auth_webauthn_finish_path = "/v1/auth/webauthn/update/finish"
 
 
 class EndpointsV2:
-    publicKeyPath = "/v2/keys"
+    public_key_path = "/v2/keys"
 
 
 class DeliveryMethod(Enum):
@@ -89,21 +89,21 @@ class DeliveryMethod(Enum):
 
 class LoginOptions:
     def __init__(
-        self, stepup: bool = False, mfa: bool = False, customClaims: dict = None
+        self, stepup: bool = False, mfa: bool = False, custom_claims: dict = None
     ):
         self.stepup = stepup
-        self.customClaims = customClaims
+        self.customClaims = custom_claims
         self.mfa = mfa
 
 
-def validateRefreshTokenProvided(
+def validate_refresh_token_provided(
     login_options: LoginOptions = None, refresh_token: str = None
 ):
-    refreshRequired = login_options is not None and (
+    refresh_required = login_options is not None and (
         login_options.mfa or login_options.stepup
     )
-    refreshMissing = refresh_token is None or refresh_token == ""
-    if refreshRequired and refreshMissing:
+    refresh_missing = refresh_token is None or refresh_token == ""
+    if refresh_required and refresh_missing:
         raise AuthException(
             400,
             ERROR_TYPE_INVALID_ARGUMENT,

--- a/descope/descope_client.py
+++ b/descope/descope_client.py
@@ -235,7 +235,7 @@ class DescopeClient:
                 f"signed refresh token {refresh_token} is empty",
             )
 
-        uri = EndpointsV1.logoutPath
+        uri = EndpointsV1.logout_path
         return self._auth.do_post(uri, {}, None, refresh_token)
 
     def logout_all(self, refresh_token: str) -> requests.Response:
@@ -258,7 +258,7 @@ class DescopeClient:
                 f"signed refresh token {refresh_token} is empty",
             )
 
-        uri = EndpointsV1.logoutAllPath
+        uri = EndpointsV1.logout_all_path
         return self._auth.do_post(uri, {}, None, refresh_token)
 
     def me(self, refresh_token: str) -> dict:
@@ -282,7 +282,7 @@ class DescopeClient:
                 f"signed refresh token {refresh_token} is empty",
             )
 
-        uri = EndpointsV1.mePath
+        uri = EndpointsV1.me_path
         response = self._auth.do_get(uri, None, None, refresh_token)
         return response.json()
 

--- a/descope/management/access_key.py
+++ b/descope/management/access_key.py
@@ -45,7 +45,7 @@ class AccessKey:
         AuthException: raised if create operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.accessKeyCreatePath,
+            MgmtV1.access_key_create_path,
             AccessKey._compose_create_body(name, expire_time, role_names, key_tenants),
             pswd=self._auth.management_key,
         )
@@ -70,7 +70,7 @@ class AccessKey:
         AuthException: raised if load operation fails
         """
         response = self._auth.do_get(
-            MgmtV1.accessKeyLoadPath,
+            MgmtV1.access_key_load_path,
             {"id": id},
             pswd=self._auth.management_key,
         )
@@ -95,7 +95,7 @@ class AccessKey:
         AuthException: raised if search operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.accessKeysSearchPath,
+            MgmtV1.access_keys_search_path,
             {"tenantIds": tenant_ids},
             pswd=self._auth.management_key,
         )
@@ -118,7 +118,7 @@ class AccessKey:
         AuthException: raised if update operation fails
         """
         self._auth.do_post(
-            MgmtV1.accessKeyUpdatePath,
+            MgmtV1.access_key_update_path,
             {"id": id, "name": name},
             pswd=self._auth.management_key,
         )
@@ -138,7 +138,7 @@ class AccessKey:
         AuthException: raised if deactivation operation fails
         """
         self._auth.do_post(
-            MgmtV1.accessKeyDeactivatePath,
+            MgmtV1.access_key_deactivate_path,
             {"id": id},
             pswd=self._auth.management_key,
         )
@@ -158,7 +158,7 @@ class AccessKey:
         AuthException: raised if activation operation fails
         """
         self._auth.do_post(
-            MgmtV1.accessKeyActivatePath,
+            MgmtV1.access_key_activate_path,
             {"id": id},
             pswd=self._auth.management_key,
         )
@@ -177,7 +177,7 @@ class AccessKey:
         AuthException: raised if creation operation fails
         """
         self._auth.do_post(
-            MgmtV1.accessKeyDeletePath,
+            MgmtV1.access_key_delete_path,
             {"id": id},
             pswd=self._auth.management_key,
         )

--- a/descope/management/common.py
+++ b/descope/management/common.py
@@ -3,59 +3,59 @@ from typing import List
 
 class MgmtV1:
     # tenant
-    tenantCreatePath = "/v1/mgmt/tenant/create"
-    tenantUpdatePath = "/v1/mgmt/tenant/update"
-    tenantDeletePath = "/v1/mgmt/tenant/delete"
-    tenantLoadAllPath = "/v1/mgmt/tenant/all"
+    tenant_create_path = "/v1/mgmt/tenant/create"
+    tenant_update_path = "/v1/mgmt/tenant/update"
+    tenant_delete_path = "/v1/mgmt/tenant/delete"
+    tenant_load_all_path = "/v1/mgmt/tenant/all"
 
     # user
-    userCreatePath = "/v1/mgmt/user/create"
-    userUpdatePath = "/v1/mgmt/user/update"
-    userDeletePath = "/v1/mgmt/user/delete"
-    userLoadPath = "/v1/mgmt/user"
-    usersSearchPath = "/v1/mgmt/user/search"
-    userUpdateStatusPath = "/v1/mgmt/user/update/status"
-    userUpdateEmailPath = "/v1/mgmt/user/update/email"
-    userUpdatePhonePath = "/v1/mgmt/user/update/phone"
-    userUpdateNamePath = "/v1/mgmt/user/update/name"
-    userAddRolePath = "/v1/mgmt/user/update/role/add"
-    userRemoveRolePath = "/v1/mgmt/user/update/role/remove"
-    userAddTenantPath = "/v1/mgmt/user/update/tenant/add"
-    userRemoveTenantPath = "/v1/mgmt/user/update/tenant/remove"
+    user_create_path = "/v1/mgmt/user/create"
+    user_update_path = "/v1/mgmt/user/update"
+    user_delete_path = "/v1/mgmt/user/delete"
+    user_load_path = "/v1/mgmt/user"
+    users_search_path = "/v1/mgmt/user/search"
+    user_update_status_path = "/v1/mgmt/user/update/status"
+    user_update_email_path = "/v1/mgmt/user/update/email"
+    user_update_phone_path = "/v1/mgmt/user/update/phone"
+    user_update_name_path = "/v1/mgmt/user/update/name"
+    user_add_role_path = "/v1/mgmt/user/update/role/add"
+    user_remove_role_path = "/v1/mgmt/user/update/role/remove"
+    user_add_tenant_path = "/v1/mgmt/user/update/tenant/add"
+    user_remove_tenant_path = "/v1/mgmt/user/update/tenant/remove"
 
     # access key
-    accessKeyCreatePath = "/v1/mgmt/accesskey/create"
-    accessKeyLoadPath = "/v1/mgmt/accesskey"
-    accessKeysSearchPath = "/v1/mgmt/accesskey/search"
-    accessKeyUpdatePath = "/v1/mgmt/accesskey/update"
-    accessKeyDeactivatePath = "/v1/mgmt/accesskey/deactivate"
-    accessKeyActivatePath = "/v1/mgmt/accesskey/activate"
-    accessKeyDeletePath = "/v1/mgmt/accesskey/delete"
+    access_key_create_path = "/v1/mgmt/accesskey/create"
+    access_key_load_path = "/v1/mgmt/accesskey"
+    access_keys_search_path = "/v1/mgmt/accesskey/search"
+    access_key_update_path = "/v1/mgmt/accesskey/update"
+    access_key_deactivate_path = "/v1/mgmt/accesskey/deactivate"
+    access_key_activate_path = "/v1/mgmt/accesskey/activate"
+    access_key_delete_path = "/v1/mgmt/accesskey/delete"
 
     # sso
-    ssoConfigurePath = "/v1/mgmt/sso/settings"
-    ssoMetadataPath = "/v1/mgmt/sso/metadata"
-    ssoMappingPath = "/v1/mgmt/sso/mapping"
+    sso_configure_path = "/v1/mgmt/sso/settings"
+    sso_metadata_path = "/v1/mgmt/sso/metadata"
+    sso_mapping_path = "/v1/mgmt/sso/mapping"
 
     # jwt
-    updateJwt = "/v1/mgmt/jwt/update"
+    update_jwt_path = "/v1/mgmt/jwt/update"
 
     # permission
-    permissionCreatePath = "/v1/mgmt/permission/create"
-    permissionUpdatePath = "/v1/mgmt/permission/update"
-    permissionDeletePath = "/v1/mgmt/permission/delete"
-    permissionLoadAllPath = "/v1/mgmt/permission/all"
+    permission_create_path = "/v1/mgmt/permission/create"
+    permission_update_path = "/v1/mgmt/permission/update"
+    permission_delete_path = "/v1/mgmt/permission/delete"
+    permission_load_all_path = "/v1/mgmt/permission/all"
 
     # role
-    roleCreatePath = "/v1/mgmt/role/create"
-    roleUpdatePath = "/v1/mgmt/role/update"
-    roleDeletePath = "/v1/mgmt/role/delete"
-    roleLoadAllPath = "/v1/mgmt/role/all"
+    role_create_path = "/v1/mgmt/role/create"
+    role_update_path = "/v1/mgmt/role/update"
+    role_delete_path = "/v1/mgmt/role/delete"
+    role_load_all_path = "/v1/mgmt/role/all"
 
     # group
-    groupLoadAllPath = "/v1/mgmt/group/all"
-    groupLoadAllForMemberPath = "/v1/mgmt/group/member/all"
-    groupLoadAllGroupMembersPath = "/v1/mgmt/group/members"
+    group_load_all_path = "/v1/mgmt/group/all"
+    group_load_all_for_member_path = "/v1/mgmt/group/member/all"
+    group_load_all_group_members_path = "/v1/mgmt/group/members"
 
 
 class AssociatedTenant:

--- a/descope/management/group.py
+++ b/descope/management/group.py
@@ -41,7 +41,7 @@ class Group:
         AuthException: raised if load operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.groupLoadAllPath,
+            MgmtV1.group_load_all_path,
             {
                 "tenantId": tenant_id,
             },
@@ -84,7 +84,7 @@ class Group:
         AuthException: raised if load operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.groupLoadAllForMemberPath,
+            MgmtV1.group_load_all_for_member_path,
             {
                 "tenantId": tenant_id,
                 "loginIds": login_ids,
@@ -127,7 +127,7 @@ class Group:
         AuthException: raised if load operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.groupLoadAllGroupMembersPath,
+            MgmtV1.group_load_all_group_members_path,
             {
                 "tenantId": tenant_id,
                 "groupId": group_id,

--- a/descope/management/jwt.py
+++ b/descope/management/jwt.py
@@ -9,7 +9,7 @@ class JWT:
     def __init__(self, auth: Auth):
         self._auth = auth
 
-    def updateJWT(self, jwt: str, custom_claims: dict) -> str:
+    def update_jwt(self, jwt: str, custom_claims: dict) -> str:
         """
         Given a valid JWT, update it with custom claims, and update its authz claims as well
 
@@ -25,7 +25,7 @@ class JWT:
         if not jwt:
             raise AuthException(400, ERROR_TYPE_INVALID_ARGUMENT, "jwt cannot be empty")
         response = self._auth.do_post(
-            MgmtV1.updateJwt,
+            MgmtV1.update_jwt_path,
             {"jwt": jwt, "customClaims": custom_claims},
             pswd=self._auth.management_key,
         )

--- a/descope/management/permission.py
+++ b/descope/management/permission.py
@@ -24,7 +24,7 @@ class Permission:
         AuthException: raised if creation operation fails
         """
         self._auth.do_post(
-            MgmtV1.permissionCreatePath,
+            MgmtV1.permission_create_path,
             {"name": name, "description": description},
             pswd=self._auth.management_key,
         )
@@ -48,7 +48,7 @@ class Permission:
         AuthException: raised if update operation fails
         """
         self._auth.do_post(
-            MgmtV1.permissionUpdatePath,
+            MgmtV1.permission_update_path,
             {"name": name, "newName": new_name, "description": description},
             pswd=self._auth.management_key,
         )
@@ -67,7 +67,7 @@ class Permission:
         AuthException: raised if creation operation fails
         """
         self._auth.do_post(
-            MgmtV1.permissionDeletePath,
+            MgmtV1.permission_delete_path,
             {"name": name},
             pswd=self._auth.management_key,
         )
@@ -87,7 +87,7 @@ class Permission:
         AuthException: raised if load operation fails
         """
         response = self._auth.do_get(
-            MgmtV1.permissionLoadAllPath,
+            MgmtV1.permission_load_all_path,
             pswd=self._auth.management_key,
         )
         return response.json()

--- a/descope/management/role.py
+++ b/descope/management/role.py
@@ -28,7 +28,7 @@ class Role:
         AuthException: raised if creation operation fails
         """
         self._auth.do_post(
-            MgmtV1.roleCreatePath,
+            MgmtV1.role_create_path,
             {
                 "name": name,
                 "description": description,
@@ -58,7 +58,7 @@ class Role:
         AuthException: raised if update operation fails
         """
         self._auth.do_post(
-            MgmtV1.roleUpdatePath,
+            MgmtV1.role_update_path,
             {
                 "name": name,
                 "newName": new_name,
@@ -82,7 +82,7 @@ class Role:
         AuthException: raised if creation operation fails
         """
         self._auth.do_post(
-            MgmtV1.roleDeletePath,
+            MgmtV1.role_delete_path,
             {"name": name},
             pswd=self._auth.management_key,
         )
@@ -102,7 +102,7 @@ class Role:
         AuthException: raised if load operation fails
         """
         response = self._auth.do_get(
-            MgmtV1.roleLoadAllPath,
+            MgmtV1.role_load_all_path,
             pswd=self._auth.management_key,
         )
         return response.json()

--- a/descope/management/sso_settings.py
+++ b/descope/management/sso_settings.py
@@ -58,7 +58,7 @@ class SSOSettings:
         AuthException: raised if configuration operation fails
         """
         self._auth.do_post(
-            MgmtV1.ssoConfigurePath,
+            MgmtV1.sso_configure_path,
             SSOSettings._compose_configure_body(
                 tenant_id, idp_url, entity_id, idp_cert, redirect_url, domain
             ),
@@ -81,7 +81,7 @@ class SSOSettings:
         AuthException: raised if configuration operation fails
         """
         self._auth.do_post(
-            MgmtV1.ssoMetadataPath,
+            MgmtV1.sso_metadata_path,
             SSOSettings._compose_metadata_body(tenant_id, idp_metadata_url),
             pswd=self._auth.management_key,
         )
@@ -104,7 +104,7 @@ class SSOSettings:
         AuthException: raised if configuration operation fails
         """
         self._auth.do_post(
-            MgmtV1.ssoMappingPath,
+            MgmtV1.sso_mapping_path,
             SSOSettings._compose_mapping_body(
                 tenant_id, role_mappings, attribute_mapping
             ),

--- a/descope/management/tenant.py
+++ b/descope/management/tenant.py
@@ -33,7 +33,7 @@ class Tenant:
         Raise:
         AuthException: raised if creation operation fails
         """
-        uri = MgmtV1.tenantCreatePath
+        uri = MgmtV1.tenant_create_path
         response = self._auth.do_post(
             uri,
             Tenant._compose_create_update_body(name, id, self_provisioning_domains),
@@ -60,7 +60,7 @@ class Tenant:
         Raise:
         AuthException: raised if creation operation fails
         """
-        uri = MgmtV1.tenantUpdatePath
+        uri = MgmtV1.tenant_update_path
         self._auth.do_post(
             uri,
             Tenant._compose_create_update_body(name, id, self_provisioning_domains),
@@ -80,7 +80,7 @@ class Tenant:
         Raise:
         AuthException: raised if creation operation fails
         """
-        uri = MgmtV1.tenantDeletePath
+        uri = MgmtV1.tenant_delete_path
         self._auth.do_post(uri, {"id": id}, pswd=self._auth.management_key)
 
     def load_all(
@@ -98,7 +98,7 @@ class Tenant:
         AuthException: raised if load operation fails
         """
         response = self._auth.do_get(
-            MgmtV1.tenantLoadAllPath,
+            MgmtV1.tenant_load_all_path,
             pswd=self._auth.management_key,
         )
         return response.json()

--- a/descope/management/user.py
+++ b/descope/management/user.py
@@ -45,7 +45,7 @@ class User:
         AuthException: raised if update operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.userCreatePath,
+            MgmtV1.user_create_path,
             User._compose_create_update_body(
                 login_id, email, phone, display_name, role_names, user_tenants
             ),
@@ -80,7 +80,7 @@ class User:
         AuthException: raised if creation operation fails
         """
         self._auth.do_post(
-            MgmtV1.userUpdatePath,
+            MgmtV1.user_update_path,
             User._compose_create_update_body(
                 login_id, email, phone, display_name, role_names, user_tenants
             ),
@@ -101,7 +101,7 @@ class User:
         AuthException: raised if creation operation fails
         """
         self._auth.do_post(
-            MgmtV1.userDeletePath,
+            MgmtV1.user_delete_path,
             {"loginId": login_id},
             pswd=self._auth.management_key,
         )
@@ -125,7 +125,7 @@ class User:
         AuthException: raised if load operation fails
         """
         response = self._auth.do_get(
-            MgmtV1.userLoadPath,
+            MgmtV1.user_load_path,
             {"loginId": login_id},
             pswd=self._auth.management_key,
         )
@@ -151,7 +151,7 @@ class User:
         AuthException: raised if load operation fails
         """
         response = self._auth.do_get(
-            MgmtV1.userLoadPath,
+            MgmtV1.user_load_path,
             {"userId": user_id},
             pswd=self._auth.management_key,
         )
@@ -180,7 +180,7 @@ class User:
         AuthException: raised if search operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.usersSearchPath,
+            MgmtV1.users_search_path,
             {"tenantIds": tenant_ids, "roleNames": role_names, "limit": limit},
             pswd=self._auth.management_key,
         )
@@ -205,7 +205,7 @@ class User:
         AuthException: raised if activate operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.userUpdateStatusPath,
+            MgmtV1.user_update_status_path,
             {"loginId": login_id, "status": "enabled"},
             pswd=self._auth.management_key,
         )
@@ -230,7 +230,7 @@ class User:
         AuthException: raised if deactivate operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.userUpdateStatusPath,
+            MgmtV1.user_update_status_path,
             {"loginId": login_id, "status": "disabled"},
             pswd=self._auth.management_key,
         )
@@ -259,7 +259,7 @@ class User:
         AuthException: raised if the update operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.userUpdateEmailPath,
+            MgmtV1.user_update_email_path,
             {"loginId": login_id, "email": email, "verified": verified},
             pswd=self._auth.management_key,
         )
@@ -288,7 +288,7 @@ class User:
         AuthException: raised if the update operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.userUpdatePhonePath,
+            MgmtV1.user_update_phone_path,
             {"loginId": login_id, "phone": phone, "verified": verified},
             pswd=self._auth.management_key,
         )
@@ -315,7 +315,7 @@ class User:
         AuthException: raised if the update operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.userUpdateNamePath,
+            MgmtV1.user_update_name_path,
             {"loginId": login_id, "displayName": display_name},
             pswd=self._auth.management_key,
         )
@@ -343,7 +343,7 @@ class User:
         AuthException: raised if the operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.userAddRolePath,
+            MgmtV1.user_add_role_path,
             {"loginId": login_id, "roleNames": role_names},
             pswd=self._auth.management_key,
         )
@@ -371,7 +371,7 @@ class User:
         AuthException: raised if the operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.userRemoveRolePath,
+            MgmtV1.user_remove_role_path,
             {"loginId": login_id, "roleNames": role_names},
             pswd=self._auth.management_key,
         )
@@ -398,7 +398,7 @@ class User:
         AuthException: raised if the operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.userAddTenantPath,
+            MgmtV1.user_add_tenant_path,
             {"loginId": login_id, "tenantId": tenant_id},
             pswd=self._auth.management_key,
         )
@@ -425,7 +425,7 @@ class User:
         AuthException: raised if the operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.userRemoveTenantPath,
+            MgmtV1.user_remove_tenant_path,
             {"loginId": login_id, "tenantId": tenant_id},
             pswd=self._auth.management_key,
         )
@@ -454,7 +454,7 @@ class User:
         AuthException: raised if the operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.userAddRolePath,
+            MgmtV1.user_add_role_path,
             {"loginId": login_id, "tenantId": tenant_id, "roleNames": role_names},
             pswd=self._auth.management_key,
         )
@@ -483,7 +483,7 @@ class User:
         AuthException: raised if the operation fails
         """
         response = self._auth.do_post(
-            MgmtV1.userRemoveRolePath,
+            MgmtV1.user_remove_role_path,
             {"loginId": login_id, "tenantId": tenant_id, "roleNames": role_names},
             pswd=self._auth.management_key,
         )

--- a/poetry.lock
+++ b/poetry.lock
@@ -796,6 +796,21 @@ files = [
 ]
 
 [[package]]
+name = "pep8-naming"
+version = "0.13.3"
+description = "Check PEP-8 naming conventions, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pep8-naming-0.13.3.tar.gz", hash = "sha256:1705f046dfcd851378aac3be1cd1551c7c1e5ff363bacad707d43007877fa971"},
+    {file = "pep8_naming-0.13.3-py3-none-any.whl", hash = "sha256:1a86b8c71a03337c97181917e2b472f0f5e4ccb06844a0d6f0a33522549e7a80"},
+]
+
+[package.dependencies]
+flake8 = ">=5.0.0"
+
+[[package]]
 name = "platformdirs"
 version = "2.6.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -1041,14 +1056,14 @@ doc = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "setuptools"
-version = "67.3.1"
+version = "67.3.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.3.1-py3-none-any.whl", hash = "sha256:23c86b4e44432bfd8899384afc08872ec166a24f48a3f99f293b0a557e6a6b5d"},
-    {file = "setuptools-67.3.1.tar.gz", hash = "sha256:daec07fd848d80676694d6bf69c009d28910aeece68a38dbe88b7e1bb6dba12e"},
+    {file = "setuptools-67.3.2-py3-none-any.whl", hash = "sha256:bb6d8e508de562768f2027902929f8523932fcd1fb784e6d573d2cafac995a48"},
+    {file = "setuptools-67.3.2.tar.gz", hash = "sha256:95f00380ef2ffa41d9bba85d95b27689d923c93dfbafed4aecd7cf988a25e012"},
 ]
 
 [package.extras]
@@ -1202,4 +1217,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "0a68c98d603ee77702ade3c91c5c0797c5d94e14d0e66ad98abf167c21c2296c"
+content-hash = "e975150cb421dbe6686ab56e60196fdaa789bd91ddbed54bfcee21e8abdaa2f7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ pytest = "7.2.1"
 black = "22.12.0"
 liccheck = "0.8.3"
 isort = "5.11.4"
+pep8-naming = "0.13.3"
 
 [build-system]
 requires = ["poetry-core>=1.1.0"]

--- a/samples/decorators/flask_decorators.py
+++ b/samples/decorators/flask_decorators.py
@@ -20,8 +20,8 @@ from descope import (  # noqa: E402
 )
 
 
-def set_cookie_on_response(response: Response, token: dict, cookieData: dict):
-    cookie_domain = cookieData.get("domain", "")
+def set_cookie_on_response(response: Response, token: dict, cookie_data: dict):
+    cookie_domain = cookie_data.get("domain", "")
     if cookie_domain == "":
         cookie_domain = None
 
@@ -31,9 +31,9 @@ def set_cookie_on_response(response: Response, token: dict, cookieData: dict):
     return response.set_cookie(
         key=token.get("drn", ""),
         value=token.get("jwt", ""),
-        max_age=cookieData.get("maxAge", int(expire_time.timestamp())),
-        expires=cookieData.get("exp", expire_time),
-        path=cookieData.get("path", "/"),
+        max_age=cookie_data.get("maxAge", int(expire_time.timestamp())),
+        expires=cookie_data.get("exp", expire_time),
+        path=cookie_data.get("path", "/"),
         domain=cookie_domain,
         secure=False,  # True
         httponly=True,

--- a/samples/enchantedlink_sample_app.py
+++ b/samples/enchantedlink_sample_app.py
@@ -37,8 +37,8 @@ def main():
             uri="http://test.me",
         )
 
-        linkIdentifier = resp["linkId"]
-        logging.info(f"Please click the link with the identifier {linkIdentifier}")
+        link_identifier = resp["linkId"]
+        logging.info(f"Please click the link with the identifier {link_identifier}")
         pending_ref = resp["pendingRef"]
 
         done = False

--- a/samples/otp_web_sample_app.py
+++ b/samples/otp_web_sample_app.py
@@ -26,8 +26,8 @@ PROJECT_ID = ""
 descope_client = DescopeClient(PROJECT_ID, skip_verify=True)
 
 
-def set_cookie_on_response(response: Response, token: dict, cookieData: dict):
-    cookie_domain = cookieData.get("domain", "")
+def set_cookie_on_response(response: Response, token: dict, cookie_data: dict):
+    cookie_domain = cookie_data.get("domain", "")
     if cookie_domain == "":
         cookie_domain = None
 
@@ -37,9 +37,9 @@ def set_cookie_on_response(response: Response, token: dict, cookieData: dict):
     return response.set_cookie(
         key=token.get("drn", ""),
         value=token.get("jwt", ""),
-        max_age=cookieData.get("maxAge", int(expire_time.timestamp())),
-        expires=cookieData.get("exp", expire_time),
-        path=cookieData.get("path", "/"),
+        max_age=cookie_data.get("maxAge", int(expire_time.timestamp())),
+        expires=cookie_data.get("exp", expire_time),
+        path=cookie_data.get("path", "/"),
         domain=cookie_domain,
         secure=False,  # True
         httponly=True,

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,7 +2,7 @@ import platform
 
 import pkg_resources
 
-defaultHeaders = {
+default_headers = {
     "Content-Type": "application/json",
     "x-descope-sdk-name": "python",
     "x-descope-sdk-python-version": platform.python_version(),

--- a/tests/management/test_access_key.py
+++ b/tests/management/test_access_key.py
@@ -57,12 +57,12 @@ class TestAccessKey(unittest.TestCase):
                     AssociatedTenant("tenant2", ["role1", "role2"]),
                 ],
             )
-            accessKey = resp["key"]
-            self.assertEqual(accessKey["id"], "ak1")
+            access_key = resp["key"]
+            self.assertEqual(access_key["id"], "ak1")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.accessKeyCreatePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.access_key_create_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -105,12 +105,12 @@ class TestAccessKey(unittest.TestCase):
             network_resp.json.return_value = json.loads("""{"key": {"id": "ak1"}}""")
             mock_get.return_value = network_resp
             resp = client.mgmt.access_key.load("key-id")
-            accessKey = resp["key"]
-            self.assertEqual(accessKey["id"], "ak1")
+            access_key = resp["key"]
+            self.assertEqual(access_key["id"], "ak1")
             mock_get.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.accessKeyLoadPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.access_key_load_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params={"id": "key-id"},
@@ -149,9 +149,9 @@ class TestAccessKey(unittest.TestCase):
             self.assertEqual(keys[0]["id"], "ak1")
             self.assertEqual(keys[1]["id"], "ak2")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.accessKeysSearchPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.access_keys_search_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -192,9 +192,9 @@ class TestAccessKey(unittest.TestCase):
                 )
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.accessKeyUpdatePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.access_key_update_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -230,9 +230,9 @@ class TestAccessKey(unittest.TestCase):
             mock_post.return_value.ok = True
             self.assertIsNone(client.mgmt.access_key.deactivate("ak1"))
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.accessKeyDeactivatePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.access_key_deactivate_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -267,9 +267,9 @@ class TestAccessKey(unittest.TestCase):
             mock_post.return_value.ok = True
             self.assertIsNone(client.mgmt.access_key.activate("ak1"))
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.accessKeyActivatePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.access_key_activate_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -304,9 +304,9 @@ class TestAccessKey(unittest.TestCase):
             mock_post.return_value.ok = True
             self.assertIsNone(client.mgmt.access_key.delete("ak1"))
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.accessKeyDeletePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.access_key_delete_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,

--- a/tests/management/test_group.py
+++ b/tests/management/test_group.py
@@ -45,9 +45,9 @@ class TestGroup(unittest.TestCase):
             mock_post.return_value.ok = True
             self.assertIsNotNone(client.mgmt.group.load_all_groups("someTenantId"))
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.groupLoadAllPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.group_load_all_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -86,9 +86,9 @@ class TestGroup(unittest.TestCase):
                 )
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.groupLoadAllForMemberPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.group_load_all_for_member_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -128,9 +128,9 @@ class TestGroup(unittest.TestCase):
                 client.mgmt.group.load_all_group_members("someTenantId", "someGroupId")
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.groupLoadAllGroupMembersPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.group_load_all_group_members_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,

--- a/tests/management/test_jwt.py
+++ b/tests/management/test_jwt.py
@@ -35,11 +35,11 @@ class TestUser(unittest.TestCase):
         with patch("requests.post") as mock_post:
             mock_post.return_value.ok = False
             self.assertRaises(
-                AuthException, client.mgmt.jwt.updateJWT, "jwt", {"k1": "v1"}
+                AuthException, client.mgmt.jwt.update_jwt, "jwt", {"k1": "v1"}
             )
 
             self.assertRaises(
-                AuthException, client.mgmt.jwt.updateJWT, "", {"k1": "v1"}
+                AuthException, client.mgmt.jwt.update_jwt, "", {"k1": "v1"}
             )
 
         # Test success flow
@@ -48,13 +48,13 @@ class TestUser(unittest.TestCase):
             network_resp.ok = True
             network_resp.json.return_value = json.loads("""{"jwt": "response"}""")
             mock_post.return_value = network_resp
-            resp = client.mgmt.jwt.updateJWT("test", {"k1": "v1"})
+            resp = client.mgmt.jwt.update_jwt("test", {"k1": "v1"})
             self.assertEqual(resp, "response")
-            expected_uri = f"{DEFAULT_BASE_URL}{MgmtV1.updateJwt}"
+            expected_uri = f"{DEFAULT_BASE_URL}{MgmtV1.update_jwt_path}"
             mock_post.assert_called_with(
                 expected_uri,
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 data=json.dumps({"jwt": "test", "customClaims": {"k1": "v1"}}),

--- a/tests/management/test_permission.py
+++ b/tests/management/test_permission.py
@@ -46,9 +46,9 @@ class TestPermission(unittest.TestCase):
             mock_post.return_value.ok = True
             self.assertIsNone(client.mgmt.permission.create("P1", "Something"))
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.permissionCreatePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.permission_create_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -91,9 +91,9 @@ class TestPermission(unittest.TestCase):
                 )
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.permissionUpdatePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.permission_update_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -130,9 +130,9 @@ class TestPermission(unittest.TestCase):
             mock_post.return_value.ok = True
             self.assertIsNone(client.mgmt.permission.delete("name"))
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.permissionDeletePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.permission_delete_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -172,9 +172,9 @@ class TestPermission(unittest.TestCase):
             self.assertEqual(permissions[0]["name"], "p1")
             self.assertEqual(permissions[1]["name"], "p2")
             mock_get.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.permissionLoadAllPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.permission_load_all_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,

--- a/tests/management/test_role.py
+++ b/tests/management/test_role.py
@@ -46,9 +46,9 @@ class TestRole(unittest.TestCase):
             mock_post.return_value.ok = True
             self.assertIsNone(client.mgmt.role.create("R1", "Something", ["P1"]))
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.roleCreatePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.role_create_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -93,9 +93,9 @@ class TestRole(unittest.TestCase):
                 )
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.roleUpdatePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.role_update_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -133,9 +133,9 @@ class TestRole(unittest.TestCase):
             mock_post.return_value.ok = True
             self.assertIsNone(client.mgmt.role.delete("name"))
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.roleDeletePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.role_delete_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -186,9 +186,9 @@ class TestRole(unittest.TestCase):
             self.assertEqual(permissions[0], "P1")
             self.assertEqual(permissions[1], "P2")
             mock_get.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.roleLoadAllPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.role_load_all_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,

--- a/tests/management/test_sso_settings.py
+++ b/tests/management/test_sso_settings.py
@@ -59,9 +59,9 @@ class TestSSOSettings(unittest.TestCase):
                 )
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.ssoConfigurePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.sso_configure_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -92,9 +92,9 @@ class TestSSOSettings(unittest.TestCase):
                 )
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.ssoConfigurePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.sso_configure_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -125,9 +125,9 @@ class TestSSOSettings(unittest.TestCase):
                 )
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.ssoConfigurePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.sso_configure_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -173,9 +173,9 @@ class TestSSOSettings(unittest.TestCase):
                 )
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.ssoMetadataPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.sso_metadata_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -219,9 +219,9 @@ class TestSSOSettings(unittest.TestCase):
                 )
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.ssoMappingPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.sso_mapping_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,

--- a/tests/management/test_tenant.py
+++ b/tests/management/test_tenant.py
@@ -50,9 +50,9 @@ class TestTenant(unittest.TestCase):
             resp = client.mgmt.tenant.create("name", "t1", ["domain.com"])
             self.assertEqual(resp["id"], "t1")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.tenantCreatePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.tenant_create_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -92,9 +92,9 @@ class TestTenant(unittest.TestCase):
                 client.mgmt.tenant.update("t1", "new-name", ["domain.com"])
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.tenantUpdatePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.tenant_update_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -131,9 +131,9 @@ class TestTenant(unittest.TestCase):
             mock_post.return_value.ok = True
             self.assertIsNone(client.mgmt.tenant.delete("t1"))
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.tenantDeletePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.tenant_delete_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -180,9 +180,9 @@ class TestTenant(unittest.TestCase):
             self.assertEqual(tenants[0]["name"], "tenant1")
             self.assertEqual(tenants[1]["name"], "tenant2")
             mock_get.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.tenantLoadAllPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.tenant_load_all_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,

--- a/tests/management/test_user.py
+++ b/tests/management/test_user.py
@@ -58,9 +58,9 @@ class TestUser(unittest.TestCase):
             user = resp["user"]
             self.assertEqual(user["id"], "u1")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.userCreatePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_create_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -103,9 +103,9 @@ class TestUser(unittest.TestCase):
                 )
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.userUpdatePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_update_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -138,9 +138,9 @@ class TestUser(unittest.TestCase):
             mock_post.return_value.ok = True
             self.assertIsNone(self.client.mgmt.user.delete("u1"))
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.userDeletePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_delete_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -173,9 +173,9 @@ class TestUser(unittest.TestCase):
             user = resp["user"]
             self.assertEqual(user["id"], "u1")
             mock_get.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.userLoadPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_load_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params={"loginId": "valid-id"},
@@ -203,9 +203,9 @@ class TestUser(unittest.TestCase):
             user = resp["user"]
             self.assertEqual(user["id"], "u1")
             mock_get.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.userLoadPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_load_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params={"userId": "user-id"},
@@ -238,9 +238,9 @@ class TestUser(unittest.TestCase):
             self.assertEqual(users[0]["id"], "u1")
             self.assertEqual(users[1]["id"], "u2")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.usersSearchPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.users_search_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -275,9 +275,9 @@ class TestUser(unittest.TestCase):
             user = resp["user"]
             self.assertEqual(user["id"], "u1")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.userUpdateStatusPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_update_status_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -311,9 +311,9 @@ class TestUser(unittest.TestCase):
             user = resp["user"]
             self.assertEqual(user["id"], "u1")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.userUpdateStatusPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_update_status_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -348,9 +348,9 @@ class TestUser(unittest.TestCase):
             user = resp["user"]
             self.assertEqual(user["id"], "u1")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.userUpdateEmailPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_update_email_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -386,9 +386,9 @@ class TestUser(unittest.TestCase):
             user = resp["user"]
             self.assertEqual(user["id"], "u1")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.userUpdatePhonePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_update_phone_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -424,9 +424,9 @@ class TestUser(unittest.TestCase):
             user = resp["user"]
             self.assertEqual(user["id"], "u1")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.userUpdateNamePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_update_name_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -461,9 +461,9 @@ class TestUser(unittest.TestCase):
             user = resp["user"]
             self.assertEqual(user["id"], "u1")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.userAddRolePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_add_role_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -498,9 +498,9 @@ class TestUser(unittest.TestCase):
             user = resp["user"]
             self.assertEqual(user["id"], "u1")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.userRemoveRolePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_remove_role_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -535,9 +535,9 @@ class TestUser(unittest.TestCase):
             user = resp["user"]
             self.assertEqual(user["id"], "u1")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.userAddTenantPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_add_tenant_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -572,9 +572,9 @@ class TestUser(unittest.TestCase):
             user = resp["user"]
             self.assertEqual(user["id"], "u1")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.userRemoveTenantPath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_remove_tenant_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -612,9 +612,9 @@ class TestUser(unittest.TestCase):
             user = resp["user"]
             self.assertEqual(user["id"], "u1")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.userAddRolePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_add_role_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,
@@ -653,9 +653,9 @@ class TestUser(unittest.TestCase):
             user = resp["user"]
             self.assertEqual(user["id"], "u1")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{MgmtV1.userRemoveRolePath}",
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_remove_role_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
                 params=None,

--- a/tests/test_enchantedlink.py
+++ b/tests/test_enchantedlink.py
@@ -45,7 +45,7 @@ class TestEnchantedLink(unittest.TestCase):
             },
         )
 
-        lo = LoginOptions(stepup=True, customClaims={"k1": "v1"})
+        lo = LoginOptions(stepup=True, custom_claims={"k1": "v1"})
         self.assertEqual(
             EnchantedLink._compose_signin_body("id1", "uri1", lo),
             {
@@ -105,9 +105,9 @@ class TestEnchantedLink(unittest.TestCase):
             mock_post.return_value = my_mock_response
             res = enchantedlink.sign_in("dummy@dummy.com", "http://test.me")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{EndpointsV1.signInAuthEnchantedLinkPath}/email",
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_in_auth_enchantedlink_path}/email",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 params=None,
@@ -134,9 +134,9 @@ class TestEnchantedLink(unittest.TestCase):
                 refresh_token=refresh_token,
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{EndpointsV1.signInAuthEnchantedLinkPath}/email",
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_in_auth_enchantedlink_path}/email",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{refresh_token}",
                 },
                 params=None,
@@ -163,12 +163,12 @@ class TestEnchantedLink(unittest.TestCase):
             data = json.loads("""{"pendingRef": "aaaa", "linkId":"24"}""")
             my_mock_response.json.return_value = data
             mock_post.return_value = my_mock_response
-            lo = LoginOptions(stepup=True, customClaims={"k1": "v1"})
+            lo = LoginOptions(stepup=True, custom_claims={"k1": "v1"})
             enchantedlink.sign_in("dummy@dummy.com", "http://test.me", lo, "refresh")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{EndpointsV1.signInAuthEnchantedLinkPath}/email",
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_in_auth_enchantedlink_path}/email",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:refresh",
                 },
                 params=None,
@@ -211,9 +211,9 @@ class TestEnchantedLink(unittest.TestCase):
                 {"username": "user1", "email": "dummy@dummy.com"},
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{EndpointsV1.signUpAuthEnchantedLinkPath}/email",
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_up_auth_enchantedlink_path}/email",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 params=None,
@@ -241,9 +241,9 @@ class TestEnchantedLink(unittest.TestCase):
                 None,
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{EndpointsV1.signUpAuthEnchantedLinkPath}/email",
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_up_auth_enchantedlink_path}/email",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 params=None,
@@ -273,9 +273,9 @@ class TestEnchantedLink(unittest.TestCase):
                 "http://test.me",
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{EndpointsV1.signUpOrInAuthEnchantedLinkPath}/email",
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_up_or_in_auth_enchantedlink_path}/email",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 params=None,

--- a/tests/test_magiclink.py
+++ b/tests/test_magiclink.py
@@ -58,7 +58,7 @@ class TestMagicLink(unittest.TestCase):
             },
         )
 
-        lo = LoginOptions(stepup=True, customClaims={"k1": "v1"})
+        lo = LoginOptions(stepup=True, custom_claims={"k1": "v1"})
         self.assertEqual(
             MagicLink._compose_signin_body("id1", "uri1", lo),
             {
@@ -149,9 +149,9 @@ class TestMagicLink(unittest.TestCase):
                 refresh_token=refresh_token,
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{EndpointsV1.signInAuthMagicLinkPath}/email",
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_in_auth_magiclink_path}/email",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{refresh_token}",
                 },
                 params=None,
@@ -232,9 +232,9 @@ class TestMagicLink(unittest.TestCase):
                 )
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{EndpointsV1.signUpAuthMagicLinkPath}/email",
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_up_auth_magiclink_path}/email",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 data=json.dumps(
@@ -267,9 +267,9 @@ class TestMagicLink(unittest.TestCase):
                 )
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{EndpointsV1.signUpAuthMagicLinkPath}/email",
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_up_auth_magiclink_path}/email",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 data=json.dumps(

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -67,11 +67,11 @@ class TestOAuth(unittest.TestCase):
         with patch("requests.post") as mock_post:
             mock_post.return_value.ok = True
             oauth.start("facebook")
-            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.oauthStart}"
+            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.oauth_start_path}"
             mock_post.assert_called_with(
                 expected_uri,
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 params={"provider": "facebook"},
@@ -97,13 +97,13 @@ class TestOAuth(unittest.TestCase):
 
         with patch("requests.post") as mock_post:
             mock_post.return_value.ok = True
-            lo = LoginOptions(stepup=True, customClaims={"k1": "v1"})
+            lo = LoginOptions(stepup=True, custom_claims={"k1": "v1"})
             oauth.start("facebook", login_options=lo, refresh_token="refresh")
-            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.oauthStart}"
+            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.oauth_start_path}"
             mock_post.assert_called_with(
                 expected_uri,
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:refresh",
                 },
                 params={"provider": "facebook"},
@@ -140,9 +140,9 @@ class TestOAuth(unittest.TestCase):
             mock_post.return_value = my_mock_response
             oauth.exchange_token("c1")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{EndpointsV1.oauthExchangeTokenPath}",
+                f"{DEFAULT_BASE_URL}{EndpointsV1.oauth_exchange_token_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 params=None,

--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -173,9 +173,9 @@ class TestOTP(unittest.TestCase):
                 )
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{EndpointsV1.signUpAuthOTPPath}/email",
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_up_auth_otp_path}/email",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 params=None,
@@ -202,9 +202,9 @@ class TestOTP(unittest.TestCase):
                 client.otp.sign_up(DeliveryMethod.EMAIL, "dummy@dummy.com", None)
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{EndpointsV1.signUpAuthOTPPath}/email",
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_up_auth_otp_path}/email",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 params=None,
@@ -265,9 +265,9 @@ class TestOTP(unittest.TestCase):
                 refresh_token=refresh_token,
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{EndpointsV1.signInAuthOTPPath}/email",
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_in_auth_otp_path}/email",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{refresh_token}",
                 },
                 params=None,

--- a/tests/test_saml.py
+++ b/tests/test_saml.py
@@ -51,11 +51,11 @@ class TestSAML(unittest.TestCase):
         with patch("requests.post") as mock_post:
             mock_post.return_value.ok = True
             saml.start("tenant1", "http://dummy.com")
-            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.authSAMLStart}"
+            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.auth_saml_start_path}"
             mock_post.assert_called_with(
                 expected_uri,
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 params={"tenant": "tenant1", "redirectURL": "http://dummy.com"},
@@ -91,13 +91,13 @@ class TestSAML(unittest.TestCase):
 
         with patch("requests.post") as mock_post:
             mock_post.return_value.ok = True
-            lo = LoginOptions(stepup=True, customClaims={"k1": "v1"})
+            lo = LoginOptions(stepup=True, custom_claims={"k1": "v1"})
             saml.start("tenant1", "http://dummy.com", lo, "refresh")
-            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.authSAMLStart}"
+            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.auth_saml_start_path}"
             mock_post.assert_called_with(
                 expected_uri,
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:refresh",
                 },
                 params={"tenant": "tenant1", "redirectURL": "http://dummy.com"},
@@ -134,9 +134,9 @@ class TestSAML(unittest.TestCase):
             mock_post.return_value = my_mock_response
             saml.exchange_token("c1")
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{EndpointsV1.samlExchangeTokenPath}",
+                f"{DEFAULT_BASE_URL}{EndpointsV1.saml_exchange_token_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 params=None,

--- a/tests/test_totp.py
+++ b/tests/test_totp.py
@@ -115,9 +115,9 @@ class TestTOTP(unittest.TestCase):
                 refresh_token=refresh_token,
             )
             mock_post.assert_called_with(
-                f"{DEFAULT_BASE_URL}{EndpointsV1.verifyTOTPPath}",
+                f"{DEFAULT_BASE_URL}{EndpointsV1.verify_totp_path}",
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{refresh_token}",
                 },
                 params=None,
@@ -163,11 +163,11 @@ class TestTOTP(unittest.TestCase):
             my_mock_response.json.return_value = valid_response
             mock_post.return_value = my_mock_response
             res = totp.update_user("dummy@dummy.com", valid_jwt_token)
-            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.updateTOTPPath}"
+            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.update_totp_path}"
             mock_post.assert_called_with(
                 expected_uri,
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{valid_jwt_token}",
                 },
                 params=None,

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -108,11 +108,13 @@ class TestWebauthN(unittest.TestCase):
             mock_post.return_value = my_mock_response
             res = webauthn.sign_up_start("id1", "https://example.com")
 
-            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.signUpAuthWebauthnStart}"
+            expected_uri = (
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_up_auth_webauthn_start_path}"
+            )
             mock_post.assert_called_with(
                 expected_uri,
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 params=None,
@@ -157,12 +159,14 @@ class TestWebauthN(unittest.TestCase):
             )
             my_mock_response.json.return_value = data
             mock_post.return_value = my_mock_response
-            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.signUpAuthWebauthnFinish}"
+            expected_uri = (
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_up_auth_webauthn_finish_path}"
+            )
             webauthn.sign_up_finish("t01", "response01")
             mock_post.assert_called_with(
                 expected_uri,
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 params=None,
@@ -213,11 +217,13 @@ class TestWebauthN(unittest.TestCase):
             my_mock_response.json.return_value = valid_response
             mock_post.return_value = my_mock_response
             res = webauthn.sign_in_start("id1", "https://example.com")
-            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.signInAuthWebauthnStart}"
+            expected_uri = (
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_in_auth_webauthn_start_path}"
+            )
             mock_post.assert_called_with(
                 expected_uri,
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 params=None,
@@ -266,13 +272,15 @@ class TestWebauthN(unittest.TestCase):
             my_mock_response.ok = True
             my_mock_response.json.return_value = valid_response
             mock_post.return_value = my_mock_response
-            lo = LoginOptions(stepup=True, customClaims={"k1": "v1"})
+            lo = LoginOptions(stepup=True, custom_claims={"k1": "v1"})
             res = webauthn.sign_in_start("id1", "https://example.com", lo, "refresh")
-            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.signInAuthWebauthnStart}"
+            expected_uri = (
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_in_auth_webauthn_start_path}"
+            )
             mock_post.assert_called_with(
                 expected_uri,
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:refresh",
                 },
                 params=None,
@@ -318,13 +326,15 @@ class TestWebauthN(unittest.TestCase):
             )
             my_mock_response.json.return_value = data
             mock_post.return_value = my_mock_response
-            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.signInAuthWebauthnFinish}"
+            expected_uri = (
+                f"{DEFAULT_BASE_URL}{EndpointsV1.sign_in_auth_webauthn_finish_path}"
+            )
             webauthn.sign_in_finish("t01", "response01")
 
             mock_post.assert_called_with(
                 expected_uri,
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 params=None,
@@ -368,13 +378,11 @@ class TestWebauthN(unittest.TestCase):
             my_mock_response.json.return_value = valid_response
             mock_post.return_value = my_mock_response
             res = webauthn.sign_up_or_in_start("id1", "https://example.com")
-            expected_uri = (
-                f"{DEFAULT_BASE_URL}{EndpointsV1.signUpOrInAuthWebauthnStart}"
-            )
+            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.sign_up_or_in_auth_webauthn_start_path}"
             mock_post.assert_called_with(
                 expected_uri,
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 params=None,
@@ -443,11 +451,13 @@ class TestWebauthN(unittest.TestCase):
             res = webauthn.update_start(
                 "dummy@dummy.com", "asdasd", "https://example.com"
             )
-            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.updateAuthWebauthnStart}"
+            expected_uri = (
+                f"{DEFAULT_BASE_URL}{EndpointsV1.update_auth_webauthn_start_path}"
+            )
             mock_post.assert_called_with(
                 expected_uri,
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:asdasd",
                 },
                 params=None,
@@ -484,12 +494,14 @@ class TestWebauthN(unittest.TestCase):
             )
             my_mock_response.json.return_value = data
             mock_post.return_value = my_mock_response
-            expected_uri = f"{DEFAULT_BASE_URL}{EndpointsV1.updateAuthWebauthnFinish}"
+            expected_uri = (
+                f"{DEFAULT_BASE_URL}{EndpointsV1.update_auth_webauthn_finish_path}"
+            )
             webauthn.update_finish("t01", "response01")
             mock_post.assert_called_with(
                 expected_uri,
                 headers={
-                    **common.defaultHeaders,
+                    **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
                 params=None,


### PR DESCRIPTION
Align everything to pep8 name convention.
This PR include the following breaking changes:
1. auth/webauthn.py - `transactionID` argument of the `sign_up_finish` function has changed to `transaction_id`
2. management/jwt.py - `updateJWT` function has changed to `update_jwt`