### PR TITLE
Add support for test user

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ You can create, update, delete or load tenants:
 # You can optionally set your own ID when creating a tenant
 descope_client.mgmt.tenant.create(
     name="My First Tenant",
-    id="my-custom-id", # This is optional. If omitted
+    id="my-custom-id", # This is optional.
     self_provisioning_domains=["domain.com"],
 )
 
@@ -697,6 +697,55 @@ updated_jwt = descope_client.mgmt.jwt.update_jwt(
         "custom-key2": "custom-value2"
     },
 )
+```
+
+### Utils for your end to end (e2e) tests and integration tests
+
+To ease your e2e tests, we exposed dedicated management methods,
+that way, you don't need to use 3rd party messaging services in order to receive sign-in/up Emails or SMS, and avoid the need of parsing the code and token from them.
+
+```Python
+# User for test can be created, this user will be able to generate code/link without
+# the need of 3rd party messaging services.
+# Test user must have a loginId, other fields are optional.
+# Roles should be set directly if no tenants exist, otherwise set
+# on a per-tenant basis.
+descope_client.mgmt.user.create_test_user(
+    login_id="desmond@descope.com",
+    email="desmond@descope.com",
+    display_name="Desmond Copeland",
+    user_tenants=[
+        AssociatedTenant("my-tenant-id", ["role-name1"]),
+    ],
+)
+
+# Now test user got created, and this user will be available until you delete it,
+# you can use any management operation for test user CRUD.
+# You can also delete all test users.
+descope_client.mgmt.user.delete_all_test_users()
+
+# OTP code can be generated for test user, for example:
+resp = descope_client.mgmt.user.generate_otp_for_test_user(
+    DeliveryMethod.EMAIL, "login-id"
+)
+code = resp["code"]
+# Now you can verify the code is valid (using descope_client.*.verify for example)
+
+# Same as OTP, magic link can be generated for test user, for example:
+resp = descope_client.mgmt.user.generate_magic_link_for_test_user(
+    DeliveryMethod.EMAIL, "login-id", ""
+)
+link = resp["link"]
+
+# Enchanted link can be generated for test user, for example:
+resp = descope_client.mgmt.user.generate_enchanted_link_for_test_user(
+    "login-id", ""
+)
+link = resp["link"]
+pending_ref = resp["pendingRef"]
+
+# Note 1: The generate code/link functions, work only for test users, will not work for regular users.
+# Note 2: In case of testing sign-in / sign-up operations with test users, need to make sure to generate the code prior calling the sign-in / sign-up operations.
 ```
 
 ## API Rate limits

--- a/descope/auth.py
+++ b/descope/auth.py
@@ -214,6 +214,19 @@ class Auth:
             )
 
     @staticmethod
+    def get_method_string(method: DeliveryMethod) -> str:
+        if method is DeliveryMethod.EMAIL:
+            return "email"
+        elif method is DeliveryMethod.SMS:
+            return "phone"
+        elif method is DeliveryMethod.WHATSAPP:
+            return "whatsapp"
+        else:
+            raise AuthException(
+                400, ERROR_TYPE_INVALID_ARGUMENT, f"Unknown delivery method: {method}"
+            )
+
+    @staticmethod
     def validate_email(email: str):
         if email == "":
             raise AuthException(
@@ -309,7 +322,6 @@ class Auth:
             )
 
     def _fetch_public_keys(self) -> None:
-
         # This function called under mutex protection so no need to acquire it once again
         response = requests.get(
             f"{self.base_url}{EndpointsV2.public_key_path}/{self.project_id}",

--- a/descope/management/common.py
+++ b/descope/management/common.py
@@ -12,6 +12,7 @@ class MgmtV1:
     user_create_path = "/v1/mgmt/user/create"
     user_update_path = "/v1/mgmt/user/update"
     user_delete_path = "/v1/mgmt/user/delete"
+    user_delete_all_test_users_path = "/v1/mgmt/user/test/delete/all"
     user_load_path = "/v1/mgmt/user"
     users_search_path = "/v1/mgmt/user/search"
     user_update_status_path = "/v1/mgmt/user/update/status"
@@ -22,6 +23,9 @@ class MgmtV1:
     user_remove_role_path = "/v1/mgmt/user/update/role/remove"
     user_add_tenant_path = "/v1/mgmt/user/update/tenant/add"
     user_remove_tenant_path = "/v1/mgmt/user/update/tenant/remove"
+    user_generate_otp_for_test_path = "/v1/mgmt/tests/generate/otp"
+    user_generate_magic_link_for_test_path = "/v1/mgmt/tests/generate/magiclink"
+    user_generate_enchanted_link_for_test_path = "/v1/mgmt/tests/generate/enchantedlink"
 
     # access key
     access_key_create_path = "/v1/mgmt/accesskey/create"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -228,6 +228,25 @@ class TestAuth(unittest.TestCase):
 
         self.assertRaises(AuthException, Auth.get_login_id_by_method, AAA.DUMMY, user)
 
+    def test_get_method_string(self):
+        self.assertEqual(
+            Auth.get_method_string(DeliveryMethod.EMAIL),
+            "email",
+        )
+        self.assertEqual(
+            Auth.get_method_string(DeliveryMethod.SMS),
+            "phone",
+        )
+        self.assertEqual(
+            Auth.get_method_string(DeliveryMethod.WHATSAPP),
+            "whatsapp",
+        )
+
+        class AAA(Enum):
+            DUMMY = 4
+
+        self.assertRaises(AuthException, Auth.get_method_string, AAA.DUMMY)
+
     def test_refresh_session(self):
         dummy_refresh_token = "dummy refresh token"
         auth = Auth(self.dummy_project_id, self.public_key_dict)


### PR DESCRIPTION
## Description
Add support for test user:
- Create user for test
- Delete all test users
- Generate access (code and link) for test user

Related to: https://github.com/descope/etc/issues/1918

## Must
- [x] Tests
- [x] Documentation
