### PR TITLE
Fix VS Code tests auto discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,5 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-.vscode/
-
 # Mac OS
 .DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	"python.testing.pytestEnabled": true,
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+}


### PR DESCRIPTION
Switched to use pytest in VS Code so tests auto discovery will work and tests can be run easily.
