### PR TITLE
Aligned validate_session, validate_and_refresh_session functions response structure

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 per-file-ignores = __init__.py:F401
-ignore = E501,N818
+ignore = E501,N818,W503

--- a/descope/auth.py
+++ b/descope/auth.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import platform
@@ -402,25 +403,32 @@ class Auth:
             jwt_response["tenants"] = jwt_response.get(REFRESH_SESSION_TOKEN_NAME).get(
                 "tenants", {}
             )
+        else:
+            jwt_response["permissions"] = jwt_response.get("permissions", [])
+            jwt_response["roles"] = jwt_response.get("roles", [])
+            jwt_response["tenants"] = jwt_response.get("tenants", {})
 
         # Save the projectID also in the dict top level
-        issuer = jwt_response.get(SESSION_TOKEN_NAME, {}).get(
-            "iss", None
-        ) or jwt_response.get(REFRESH_SESSION_TOKEN_NAME, {}).get("iss", "")
+        issuer = (
+            jwt_response.get(SESSION_TOKEN_NAME, {}).get("iss", None)
+            or jwt_response.get(REFRESH_SESSION_TOKEN_NAME, {}).get("iss", None)
+            or jwt_response.get("iss", "")
+        )
         jwt_response["projectId"] = issuer.rsplit("/")[
             -1
         ]  # support both url issuer and project ID issuer
 
+        sub = (
+            jwt_response.get(SESSION_TOKEN_NAME, {}).get("sub", None)
+            or jwt_response.get(REFRESH_SESSION_TOKEN_NAME, {}).get("sub", None)
+            or jwt_response.get("sub", "")
+        )
         if user_jwt:
             # Save the userID also in the dict top level
-            jwt_response["userId"] = jwt_response.get(SESSION_TOKEN_NAME, {}).get(
-                "sub", None
-            ) or jwt_response.get(REFRESH_SESSION_TOKEN_NAME, {}).get("sub", None)
+            jwt_response["userId"] = sub
         else:
             # Save the AccessKeyID also in the dict top level
-            jwt_response["keyId"] = jwt_response.get(SESSION_TOKEN_NAME, {}).get(
-                "sub", None
-            )
+            jwt_response["keyId"] = sub
 
         return jwt_response
 
@@ -543,6 +551,9 @@ class Auth:
 
         try:
             res = self._validate_token(session_token)
+            res[SESSION_TOKEN_NAME] = copy.deepcopy(
+                res
+            )  # Duplicate for saving backward compatibility but keep the same structure as the refresh operation response
             return self.adjust_properties(res, True)
         except RateLimitException as e:
             raise e

--- a/descope/descope_client.py
+++ b/descope/descope_client.py
@@ -175,7 +175,10 @@ class DescopeClient:
         """
         Validate a session token. Call this function for every incoming request to your
         private endpoints. Alternatively, use validate_and_refresh_session in order to
-        automatically refresh expired sessions.
+        automatically refresh expired sessions. If you need to use these specific claims
+        [amr, drn, exp, iss, rexp, sub, jwt] in the top level of the response dict, please use
+        them from the sessionToken key instead, as these claims will soon be deprecated from the top level
+        of the response dict.
 
         Args:
         session_token (str): The session token to be validated

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -354,7 +354,13 @@ class TestAuth(common.DescopeTest):
     def test_adjust_properties(self):
         self.assertEqual(
             Auth.adjust_properties(self, jwt_response={}, user_jwt={}),
-            {"keyId": None, "projectId": ""},
+            {
+                "keyId": "",
+                "permissions": [],
+                "projectId": "",
+                "roles": [],
+                "tenants": {},
+            },
         )
 
         jwt_response = {

--- a/tests/test_descope_client.py
+++ b/tests/test_descope_client.py
@@ -153,6 +153,52 @@ class TestDescopeClient(common.DescopeTest):
             None,
         )
 
+    def test_validate_session_response_structure(self):
+        self.maxDiff = None
+        client = DescopeClient(
+            self.dummy_project_id,
+            {
+                "alg": "ES384",
+                "crv": "P-384",
+                "kid": "P2CuC9yv2UGtGI1o84gCZEb9qEQW",
+                "kty": "EC",
+                "use": "sig",
+                "x": "DCjjyS7blnEmenLyJVwmH6yMnp7MlEggfk1kLtOv_Khtpps_Mq4K9brqsCwQhGUP",
+                "y": "xKy4IQ2FaLEzrrl1KE5mKbioLhj1prYFk1itdTOr6Xpy1fgq86kC7v-Y2F2vpcDc",
+            },
+        )
+
+        ds = "eyJhbGciOiJFUzM4NCIsImtpZCI6IlAyQ3VDOXl2MlVHdEdJMW84NGdDWkViOXFFUVciLCJ0eXAiOiJKV1QifQ.eyJkcm4iOiJEUyIsImV4cCI6MjQ5MzA2MTQxNSwiaWF0IjoxNjU5NjQzMDYxLCJpc3MiOiJQMkN1Qzl5djJVR3RHSTFvODRnQ1pFYjlxRVFXIiwic3ViIjoiVTJDdUNQdUpnUFdIR0I1UDRHbWZidVBHaEdWbSJ9.gMalOv1GhqYVsfITcOc7Jv_fibX1Iof6AFy2KCVmyHmU2KwATT6XYXsHjBFFLq262Pg-LS1IX9f_DV3ppzvb1pSY4ccsP6WDGd1vJpjp3wFBP9Sji6WXL0SCCJUFIyJR"
+        try:
+            jwt_response = client.validate_session(ds)
+        except AuthException:
+            self.fail("Should pass validation")
+
+        self.assertEqual(
+            jwt_response,
+            {
+                "drn": "DS",
+                "exp": 2493061415,
+                "iat": 1659643061,
+                "iss": "P2CuC9yv2UGtGI1o84gCZEb9qEQW",
+                "sub": "U2CuCPuJgPWHGB5P4GmfbuPGhGVm",
+                "jwt": "eyJhbGciOiJFUzM4NCIsImtpZCI6IlAyQ3VDOXl2MlVHdEdJMW84NGdDWkViOXFFUVciLCJ0eXAiOiJKV1QifQ.eyJkcm4iOiJEUyIsImV4cCI6MjQ5MzA2MTQxNSwiaWF0IjoxNjU5NjQzMDYxLCJpc3MiOiJQMkN1Qzl5djJVR3RHSTFvODRnQ1pFYjlxRVFXIiwic3ViIjoiVTJDdUNQdUpnUFdIR0I1UDRHbWZidVBHaEdWbSJ9.gMalOv1GhqYVsfITcOc7Jv_fibX1Iof6AFy2KCVmyHmU2KwATT6XYXsHjBFFLq262Pg-LS1IX9f_DV3ppzvb1pSY4ccsP6WDGd1vJpjp3wFBP9Sji6WXL0SCCJUFIyJR",
+                "permissions": [],
+                "roles": [],
+                "tenants": {},
+                "projectId": "P2CuC9yv2UGtGI1o84gCZEb9qEQW",
+                "userId": "U2CuCPuJgPWHGB5P4GmfbuPGhGVm",
+                "sessionToken": {
+                    "drn": "DS",
+                    "exp": 2493061415,
+                    "iat": 1659643061,
+                    "iss": "P2CuC9yv2UGtGI1o84gCZEb9qEQW",
+                    "sub": "U2CuCPuJgPWHGB5P4GmfbuPGhGVm",
+                    "jwt": "eyJhbGciOiJFUzM4NCIsImtpZCI6IlAyQ3VDOXl2MlVHdEdJMW84NGdDWkViOXFFUVciLCJ0eXAiOiJKV1QifQ.eyJkcm4iOiJEUyIsImV4cCI6MjQ5MzA2MTQxNSwiaWF0IjoxNjU5NjQzMDYxLCJpc3MiOiJQMkN1Qzl5djJVR3RHSTFvODRnQ1pFYjlxRVFXIiwic3ViIjoiVTJDdUNQdUpnUFdIR0I1UDRHbWZidVBHaEdWbSJ9.gMalOv1GhqYVsfITcOc7Jv_fibX1Iof6AFy2KCVmyHmU2KwATT6XYXsHjBFFLq262Pg-LS1IX9f_DV3ppzvb1pSY4ccsP6WDGd1vJpjp3wFBP9Sji6WXL0SCCJUFIyJR",
+                },
+            },
+        )
+
     def test_validate_session_valid_tokens(self):
         client = DescopeClient(
             self.dummy_project_id,


### PR DESCRIPTION
Aligned the return value structure of `validate_session`, `validate_and_refresh_session` to be in unified structure and fix userId and projectId property on the dict response to have the correct values (instead of empty).

Note: for backward compatibility reason we keep these claims `[amr, drn, exp, iss, rexp, sub, jwt]` on the dict response top-level and its recommended to use them from the `sessionToken` key in the dict response object.

## Must
- [X] Tests
- [X] Documentation (if applicable)
