### PR TITLE
Set default of 5sec to jwt validation leeway (and also make it configurable)

### DIFF
--- a/descope/descope_client.py
+++ b/descope/descope_client.py
@@ -26,9 +26,15 @@ class DescopeClient:
         skip_verify: bool = False,
         management_key: str = None,
         timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        jwt_validation_leeway: int = 5,
     ):
         auth = Auth(
-            project_id, public_key, skip_verify, management_key, timeout_seconds
+            project_id,
+            public_key,
+            skip_verify,
+            management_key,
+            timeout_seconds,
+            jwt_validation_leeway,
         )
         self._auth = auth
         self._mgmt = MGMT(auth)


### PR DESCRIPTION
Fix cases when there is a time machine glitch between the time jwt was invoked and the time when it validated,
example for this is case where getting this error: 
`jwt.exceptions.ImmatureSignatureError: The token is not yet valid (iat)`
that means that jwt was invoked before the current time on the machine.