### PR TITLE
Check associated tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,6 +865,30 @@ except RateLimitException as e:
 
 You can find various usage samples in the [samples folder](https://github.com/descope/python-sdk/blob/main/samples).
 
+## Run Locally
+
+### Prerequisites
+ - Python 3.7 or higher
+ - [Poetry](https://python-poetry.org) installed
+
+### Install dependencies
+
+```bash
+poetry install
+```
+
+### Run tests
+
+Running all tests:
+```bash
+poetry run pytest tests
+```
+
+Running all tests with coverage:
+```bash
+poetry run pytest --junitxml=/tmp/pytest.xml --cov-report=term-missing:skip-covered --cov=descope tests/ --cov-report=xml:/tmp/cov.xml
+```
+
 ## Learn More
 
 To learn more please see the [Descope Documentation and API reference page](https://docs.descope.com/).

--- a/descope/descope_client.py
+++ b/descope/descope_client.py
@@ -124,6 +124,9 @@ class DescopeClient:
         if tenant == "":
             granted = jwt_response.get("permissions", [])
         else:
+            # ensure that the tenant is associated with the jwt_response
+            if tenant not in jwt_response.get("tenants", {}):
+                return False
             granted = (
                 jwt_response.get("tenants", {}).get(tenant, {}).get("permissions", [])
             )
@@ -170,6 +173,9 @@ class DescopeClient:
         if tenant == "":
             granted = jwt_response.get("roles", [])
         else:
+            # ensure that the tenant is associated with the jwt_response
+            if tenant not in jwt_response.get("tenants", {}):
+                return False
             granted = jwt_response.get("tenants", {}).get(tenant, {}).get("roles", [])
 
         for role in roles:

--- a/tests/test_descope_client.py
+++ b/tests/test_descope_client.py
@@ -470,6 +470,7 @@ class TestDescopeClient(common.DescopeTest):
         )
 
         jwt_response = {"tenants": {"t1": {"permissions": "Perm 1"}}}
+        self.assertTrue(client.validate_tenant_permissions(jwt_response, "t1", []))
         self.assertTrue(
             client.validate_tenant_permissions(jwt_response, "t1", ["Perm 1"])
         )
@@ -479,6 +480,7 @@ class TestDescopeClient(common.DescopeTest):
         self.assertFalse(
             client.validate_tenant_permissions(jwt_response, "t1", ["Perm 1", "Perm 2"])
         )
+        self.assertFalse(client.validate_tenant_permissions(jwt_response, "t2", []))
 
     def test_validate_roles(self):
         client = DescopeClient(self.dummy_project_id, self.public_key_dict)
@@ -503,9 +505,13 @@ class TestDescopeClient(common.DescopeTest):
 
         jwt_response = {"tenants": {"t1": {"roles": "Role 1"}}}
         self.assertTrue(client.validate_tenant_roles(jwt_response, "t1", ["Role 1"]))
+        self.assertTrue(client.validate_tenant_roles(jwt_response, "t1", []))
         self.assertFalse(client.validate_tenant_roles(jwt_response, "t1", ["Role 2"]))
         self.assertFalse(
             client.validate_tenant_roles(jwt_response, "t1", ["Role 1", "Role 2"])
+        )
+        self.assertFalse(
+            client.validate_tenant_roles(jwt_response, "t1", ["Perm 1", "Perm 2"])
         )
 
     def test_exchange_access_key_empty_param(self):


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/3104

## Description
Ensure that the user is associated to tenant before checking roles/permissions

also added instructions for running tests locally 