### PR TITLE
Fix AuthException message field format so it will include the full Descope-error object

### DIFF
--- a/descope/__init__.py
+++ b/descope/__init__.py
@@ -11,6 +11,7 @@ from descope.descope_client import DescopeClient
 from descope.exceptions import (
     API_RATE_LIMIT_RETRY_AFTER_HEADER,
     ERROR_TYPE_API_RATE_LIMIT,
+    ERROR_TYPE_SERVER_ERROR,
     AuthException,
     RateLimitException,
 )

--- a/descope/auth.py
+++ b/descope/auth.py
@@ -337,7 +337,7 @@ class Auth:
         raise AuthException(
             response.status_code,
             ERROR_TYPE_SERVER_ERROR,
-            f"Error: {response.reason}",
+            response.text,
         )
 
     def _fetch_public_keys(self) -> None:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,6 +11,7 @@ from descope.descope_client import DescopeClient
 from descope.exceptions import (
     API_RATE_LIMIT_RETRY_AFTER_HEADER,
     ERROR_TYPE_API_RATE_LIMIT,
+    ERROR_TYPE_SERVER_ERROR,
     AuthException,
     RateLimitException,
 )


### PR DESCRIPTION
Fix the error message field (in AuthException) so it will include the full Descope error information.