### PR TITLE
Support domain and redirectURL field when updating SSO metadata URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,8 @@ descope_client.mgmt.sso.configure(
 descope_client.mgmt.sso.configure_via_metadata(
     tenant_id, # Which tenant this configuration is for
     idp_metadata_url="https://idp.com/my-idp-metadata",
+    redirect_url="", # Redirect URL will have to be provided in every authentication call
+    domain="" # Remove the current domain configuration if a value was previously set
 )
 
 # Map IDP groups to Descope roles, or map user attributes.

--- a/descope/management/sso_settings.py
+++ b/descope/management/sso_settings.py
@@ -116,7 +116,7 @@ class SSOSettings(AuthBase):
         tenant_id (str): The tenant ID to be configured
         idp_metadata_url (str): The URL to fetch SSO settings from.
         redirect_url (str): The Redirect URL to use after successful authentication, or empty string to reset it.
-        domain (str): Tomain used to associate users authenticating via SSO with this tenant, or empty string to reset it.
+        domain (str): domain used to associate users authenticating via SSO with this tenant, or empty string to reset it.
 
         Raise:
         AuthException: raised if configuration operation fails

--- a/descope/management/sso_settings.py
+++ b/descope/management/sso_settings.py
@@ -77,8 +77,8 @@ class SSOSettings(AuthBase):
         idp_url: str,
         entity_id: str,
         idp_cert: str,
-        redirect_url: str = None,
-        domain: str = None,
+        redirect_url: str,
+        domain: str,
     ) -> None:
         """
         Configure SSO setting for a tenant manually. Alternatively, `configure_via_metadata` can be used instead.
@@ -88,8 +88,8 @@ class SSOSettings(AuthBase):
         idp_url (str): The URL for the identity provider.
         entity_id (str): The entity ID (in the IDP).
         idp_cert (str): The certificate provided by the IDP.
-        redirect_url (str): An Optional Redirect URL after successful authentication.
-        domain (str): An optional domain used to associate users authenticating via SSO with this tenant
+        redirect_url (str): The Redirect URL to use after successful authentication, or empty string to reset it.
+        domain (str): Tomain used to associate users authenticating via SSO with this tenant, or empty string to reset it.
 
         Raise:
         AuthException: raised if configuration operation fails
@@ -106,6 +106,8 @@ class SSOSettings(AuthBase):
         self,
         tenant_id: str,
         idp_metadata_url: str,
+        redirect_url: str,
+        domain: str,
     ):
         """
         Configure SSO setting for am IDP metadata URL. Alternatively, `configure` can be used instead.
@@ -113,13 +115,17 @@ class SSOSettings(AuthBase):
         Args:
         tenant_id (str): The tenant ID to be configured
         idp_metadata_url (str): The URL to fetch SSO settings from.
+        redirect_url (str): The Redirect URL to use after successful authentication, or empty string to reset it.
+        domain (str): Tomain used to associate users authenticating via SSO with this tenant, or empty string to reset it.
 
         Raise:
         AuthException: raised if configuration operation fails
         """
         self._auth.do_post(
             MgmtV1.sso_metadata_path,
-            SSOSettings._compose_metadata_body(tenant_id, idp_metadata_url),
+            SSOSettings._compose_metadata_body(
+                tenant_id, idp_metadata_url, redirect_url, domain
+            ),
             pswd=self._auth.management_key,
         )
 
@@ -157,8 +163,8 @@ class SSOSettings(AuthBase):
         idp_url: str,
         entity_id: str,
         idp_cert: str,
-        redirect_url: str = None,
-        domain: str = None,
+        redirect_url: str,
+        domain: str,
     ) -> dict:
         return {
             "tenantId": tenant_id,
@@ -173,10 +179,14 @@ class SSOSettings(AuthBase):
     def _compose_metadata_body(
         tenant_id: str,
         idp_metadata_url: str,
+        redirect_url: str,
+        domain: str,
     ) -> dict:
         return {
             "tenantId": tenant_id,
             "idpMetadataURL": idp_metadata_url,
+            "redirectURL": redirect_url,
+            "domain": domain,
         }
 
     @staticmethod

--- a/descope/management/sso_settings.py
+++ b/descope/management/sso_settings.py
@@ -89,7 +89,7 @@ class SSOSettings(AuthBase):
         entity_id (str): The entity ID (in the IDP).
         idp_cert (str): The certificate provided by the IDP.
         redirect_url (str): The Redirect URL to use after successful authentication, or empty string to reset it.
-        domain (str): Tomain used to associate users authenticating via SSO with this tenant, or empty string to reset it.
+        domain (str): domain used to associate users authenticating via SSO with this tenant, or empty string to reset it.
 
         Raise:
         AuthException: raised if configuration operation fails

--- a/samples/management/sso_sample_app.py
+++ b/samples/management/sso_sample_app.py
@@ -37,6 +37,8 @@ def main():
         entity_id = ""
         idp_cert = ""
         idp_metadata_url = ""
+        redirect_url = ""
+        domain = ""
         role_mappings = [RoleMapping(["a"], "Tenant Admin")]
         attribute_mapping = AttributeMapping(name="MyName")
 
@@ -47,6 +49,8 @@ def main():
                 idp_url=idp_url,
                 entity_id=entity_id,
                 idp_cert=idp_cert,
+                redirect_url=redirect_url,
+                domain=domain,
             )
 
         except AuthException as e:
@@ -57,6 +61,8 @@ def main():
             descope_client.mgmt.sso.configure_via_metadata(
                 tenant_id,
                 idp_metadata_url=idp_metadata_url,
+                redirect_url=redirect_url,
+                domain=domain,
             )
 
         except AuthException as e:

--- a/tests/management/test_sso_settings.py
+++ b/tests/management/test_sso_settings.py
@@ -166,6 +166,7 @@ class TestSSOSettings(common.DescopeTest):
                     "entity-id",
                     "cert",
                     "https://redirect.com",
+                    "",
                 )
             )
             mock_post.assert_called_with(
@@ -181,7 +182,7 @@ class TestSSOSettings(common.DescopeTest):
                     "entityId": "entity-id",
                     "idpCert": "cert",
                     "redirectURL": "https://redirect.com",
-                    "domain": None,
+                    "domain": "",
                 },
                 allow_redirects=False,
                 verify=True,
@@ -197,7 +198,8 @@ class TestSSOSettings(common.DescopeTest):
                     "https://idp.com",
                     "entity-id",
                     "cert",
-                    domain="domain.com",
+                    "",
+                    "domain.com",
                 )
             )
             mock_post.assert_called_with(
@@ -212,7 +214,7 @@ class TestSSOSettings(common.DescopeTest):
                     "idpURL": "https://idp.com",
                     "entityId": "entity-id",
                     "idpCert": "cert",
-                    "redirectURL": None,
+                    "redirectURL": "",
                     "domain": "domain.com",
                 },
                 allow_redirects=False,
@@ -236,6 +238,8 @@ class TestSSOSettings(common.DescopeTest):
                 client.mgmt.sso.configure_via_metadata,
                 "tenant-id",
                 "https://idp-meta.com",
+                "https://redirect.com",
+                "domain.com",
             )
 
         # Test success flow
@@ -245,6 +249,8 @@ class TestSSOSettings(common.DescopeTest):
                 client.mgmt.sso.configure_via_metadata(
                     "tenant-id",
                     "https://idp-meta.com",
+                    "https://redirect.com",
+                    "domain.com",
                 )
             )
             mock_post.assert_called_with(
@@ -257,6 +263,8 @@ class TestSSOSettings(common.DescopeTest):
                 json={
                     "tenantId": "tenant-id",
                     "idpMetadataURL": "https://idp-meta.com",
+                    "redirectURL": "https://redirect.com",
+                    "domain": "domain.com",
                 },
                 allow_redirects=False,
                 verify=True,


### PR DESCRIPTION
## Description
- Adds the missing `redirect_url` and `domain` parameters to the `configure_via_metadata` function.
- The `redirect_url` and `domain` parameters are now required in both `configure_via_metadata` and `configure` functions.
- When calling these functions you can either pass a valid `redirect_url` / `domain` as the parameter value, or an empty string to reset whatever's currently set.

## Impact
- This is a minor **_BREAKING CHANGE_** in that some function signatures have changed:
    - Existing calls to `configure_via_metadata` will miss the two new parameters – pass a string value for them as explained above.
    - Existing calls to `configure` might miss the parameters which had a default `None` value – pass an empty `string` to keep the same behavior.

## Must
- [X] Tests
- [X] Documentation (if applicable)
