### PR TITLE
feat(flask): adding flask decorators as a package extra

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: pyupgrade
         args: [--py37-plus]
   - repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies: [Flake8-pyproject]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: pyupgrade
         args: [--py37-plus]
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         additional_dependencies: [Flake8-pyproject]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
+        additional_dependencies: [Flake8-pyproject]
   - repo: https://github.com/python-poetry/poetry
     rev: 1.6.1
     hooks:
@@ -68,11 +69,4 @@ repos:
         args: [run, liccheck, --level, paranoid]
         language: system
         files: ^(.*requirements.*\.txt|setup\.cfg|setup\.py|pyproject\.toml|liccheck\.ini)$
-        pass_filenames: false
-      - id: tox
-        name: Run tests with tox
-        description: Run tox to check that all tests pass
-        entry: poetry run tox -p
-        language: system
-        files: ^(.*\.py)$
         pass_filenames: false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+    "recommendations": [
+        "ms-python.python",
+        "ms-python.black-formatter",
+        "ms-python.flake8",
+        "ms-python.isort",
+        "ms-python.vscode-pylance",
+        "ms-python.mypy-type-checker",
+        "bodil.prettier-toml",
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
     "python.testing.pytestArgs": [
         "tests"
     ],
-    "mypy.runUsingActiveInterpreter": true,
+    "flake8.importStrategy": "fromEnvironment",
+    "mypy-type-checker.importStrategy": "fromEnvironment",
+    "isort.importStrategy": "fromEnvironment",
+    "black-formatter.importStrategy": "fromEnvironment",
 }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Install the package with:
 pip install descope
 ```
 
+#### If you would like to use the Flask decorators, make sure to install the Flask extras:
+
+```bash
+pip install descope[Flask]
+```
+
 ## Setup
 
 A Descope `Project ID` is required to initialize the SDK. Find it on the
@@ -795,10 +801,13 @@ updated_jwt = descope_client.mgmt.jwt.update_jwt(
 ```
 
 # Note 1: The generate code/link functions, work only for test users, will not work for regular users.
+
 # Note 2: In case of testing sign-in / sign-up operations with test users, need to make sure to generate the code prior calling the sign-in / sign-up operations.
 
 # Embedded links can be created to directly receive a verifiable token without sending it.
+
 # This token can then be verified using the magic link 'verify' function, either directly or through a flow.
+
 token = descope_client.mgmt.user.generate_embedded_link("desmond@descope.com", {"key1":"value1"})
 
 ### Search Audit
@@ -885,8 +894,9 @@ You can find various usage samples in the [samples folder](https://github.com/de
 ## Run Locally
 
 ### Prerequisites
- - Python 3.7 or higher
- - [Poetry](https://python-poetry.org) installed
+
+- Python 3.7 or higher
+- [Poetry](https://python-poetry.org) installed
 
 ### Install dependencies
 
@@ -897,11 +907,13 @@ poetry install
 ### Run tests
 
 Running all tests:
+
 ```bash
 poetry run pytest tests
 ```
 
 Running all tests with coverage:
+
 ```bash
 poetry run pytest --junitxml=/tmp/pytest.xml --cov-report=term-missing:skip-covered --cov=descope tests/ --cov-report=xml:/tmp/cov.xml
 ```

--- a/descope/flask/__init__.py
+++ b/descope/flask/__init__.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import datetime
 import uuid
 from functools import wraps
 
 from flask import Response, _request_ctx_stack, redirect, request
 
-from descope import (
+from .. import (
     COOKIE_DATA_NAME,
     REFRESH_SESSION_COOKIE_NAME,
     REFRESH_SESSION_TOKEN_NAME,
@@ -13,8 +15,8 @@ from descope import (
     AuthException,
     DeliveryMethod,
 )
-from descope.descope_client import DescopeClient
-from descope.exceptions import ERROR_TYPE_INVALID_ARGUMENT
+from ..descope_client import DescopeClient
+from ..exceptions import ERROR_TYPE_INVALID_ARGUMENT
 
 
 def set_cookie_on_response(response: Response, token: dict, cookie_data: dict):
@@ -38,7 +40,7 @@ def set_cookie_on_response(response: Response, token: dict, cookie_data: dict):
     )
 
 
-def descope_signup_otp_by_email(descope_client):
+def descope_signup_otp_by_email(descope_client: DescopeClient):
     """
     Sign-up new user, using email to verify the OTP
     """
@@ -64,7 +66,7 @@ def descope_signup_otp_by_email(descope_client):
     return decorator
 
 
-def descope_signin_otp_by_email(descope_client):
+def descope_signin_otp_by_email(descope_client: DescopeClient):
     """
     Sign-in existing user, using email to verify OTP
     """
@@ -89,7 +91,12 @@ def descope_signin_otp_by_email(descope_client):
     return decorator
 
 
-def descope_validate_auth(descope_client, permissions=None, roles=None, tenant=""):
+def descope_validate_auth(
+    descope_client: DescopeClient,
+    permissions: list[str] | None = None,
+    roles: list[str] | None = None,
+    tenant="",
+):
     """
     Test if Access Token is valid
     """
@@ -152,7 +159,7 @@ def descope_validate_auth(descope_client, permissions=None, roles=None, tenant="
     return decorator
 
 
-def descope_verify_code_by_email(descope_client):
+def descope_verify_code_by_email(descope_client: DescopeClient):
     """
     Verify code by email decorator
     """
@@ -195,7 +202,7 @@ def descope_verify_code_by_email(descope_client):
     return decorator
 
 
-def descope_verify_code_by_phone(descope_client):
+def descope_verify_code_by_phone(descope_client: DescopeClient):
     """
     Verify code by email decorator
     """
@@ -238,7 +245,7 @@ def descope_verify_code_by_phone(descope_client):
     return decorator
 
 
-def descope_verify_code_by_whatsapp(descope_client):
+def descope_verify_code_by_whatsapp(descope_client: DescopeClient):
     """
     Verify code by whatsapp decorator
     """
@@ -281,7 +288,7 @@ def descope_verify_code_by_whatsapp(descope_client):
     return decorator
 
 
-def descope_signup_magiclink_by_email(descope_client, uri):
+def descope_signup_magiclink_by_email(descope_client: DescopeClient, uri: str):
     """
     Signup new user using magiclink via email
     """
@@ -307,7 +314,7 @@ def descope_signup_magiclink_by_email(descope_client, uri):
     return decorator
 
 
-def descope_signin_magiclink_by_email(descope_client, uri):
+def descope_signin_magiclink_by_email(descope_client: DescopeClient, uri: str):
     """
     Signin using magiclink via email
     """
@@ -332,7 +339,7 @@ def descope_signin_magiclink_by_email(descope_client, uri):
     return decorator
 
 
-def descope_verify_magiclink_token(descope_client):
+def descope_verify_magiclink_token(descope_client: DescopeClient):
     """
     Verify magiclink token
     """
@@ -370,7 +377,7 @@ def descope_verify_magiclink_token(descope_client):
     return decorator
 
 
-def descope_logout(descope_client):
+def descope_logout(descope_client: DescopeClient):
     """
     Logout
     """
@@ -426,7 +433,7 @@ def descope_oauth(descope_client: DescopeClient):
     return decorator
 
 
-def descope_full_login(project_id, flow_id, success_redirect_url):
+def descope_full_login(project_id: str, flow_id: str, success_redirect_url: str):
     """
     Descope Flow login
     """

--- a/poetry.lock
+++ b/poetry.lock
@@ -505,19 +505,19 @@ typing = ["typing-extensions (>=4.7.1)"]
 
 [[package]]
 name = "flake8"
-version = "6.0.0"
+version = "6.1.0"
 description = "the modular source code checker: pep8 pyflakes and co"
 optional = false
 python-versions = ">=3.8.1"
 files = [
-    {file = "flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7"},
-    {file = "flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"},
+    {file = "flake8-6.1.0-py2.py3-none-any.whl", hash = "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"},
+    {file = "flake8-6.1.0.tar.gz", hash = "sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23"},
 ]
 
 [package.dependencies]
 mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.10.0,<2.11.0"
-pyflakes = ">=3.0.0,<3.1.0"
+pycodestyle = ">=2.11.0,<2.12.0"
+pyflakes = ">=3.1.0,<3.2.0"
 
 [[package]]
 name = "flake8-bugbear"
@@ -947,13 +947,13 @@ files = [
 
 [[package]]
 name = "pycodestyle"
-version = "2.10.0"
+version = "2.11.0"
 description = "Python style guide checker"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"},
-    {file = "pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053"},
+    {file = "pycodestyle-2.11.0-py2.py3-none-any.whl", hash = "sha256:5d1013ba8dc7895b548be5afb05740ca82454fd899971563d2ef625d090326f8"},
+    {file = "pycodestyle-2.11.0.tar.gz", hash = "sha256:259bcc17857d8a8b3b4a2327324b79e5f020a13c16074670f9c8c8f872ea76d0"},
 ]
 
 [[package]]
@@ -969,13 +969,13 @@ files = [
 
 [[package]]
 name = "pyflakes"
-version = "3.0.1"
+version = "3.1.0"
 description = "passive checker of Python programs"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf"},
-    {file = "pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"},
+    {file = "pyflakes-3.1.0-py2.py3-none-any.whl", hash = "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774"},
+    {file = "pyflakes-3.1.0.tar.gz", hash = "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc"},
 ]
 
 [[package]]
@@ -1324,4 +1324,4 @@ flask = ["Flask"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<4.0"
-content-hash = "763ccb53338d7522a7aac3e4781bfa28dd033823f79fd97b7c7d7ff48bdb3215"
+content-hash = "c849b12c25c3d0bc4047d72a263c19399868db5fcc6805f613ae6983ab38053b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1324,4 +1324,4 @@ flask = ["Flask"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<4.0"
-content-hash = "6c53c15624d080b2c5caf095259aed6d328b3cb64ca0b72de57bd56450a2d9c4"
+content-hash = "763ccb53338d7522a7aac3e4781bfa28dd033823f79fd97b7c7d7ff48bdb3215"

--- a/poetry.lock
+++ b/poetry.lock
@@ -538,6 +538,23 @@ flake8 = ">=6.0.0"
 dev = ["coverage", "hypothesis", "hypothesmith (>=0.2)", "pre-commit", "pytest", "tox"]
 
 [[package]]
+name = "flake8-pyproject"
+version = "1.2.3"
+description = "Flake8 plug-in loading the configuration from pyproject.toml"
+optional = false
+python-versions = ">= 3.6"
+files = [
+    {file = "flake8_pyproject-1.2.3-py3-none-any.whl", hash = "sha256:6249fe53545205af5e76837644dc80b4c10037e73a0e5db87ff562d75fb5bd4a"},
+]
+
+[package.dependencies]
+Flake8 = ">=5"
+TOMLi = {version = "*", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["pyTest", "pyTest-cov"]
+
+[[package]]
 name = "flask"
 version = "2.3.2"
 description = "A simple framework for building complex web applications."
@@ -1301,7 +1318,10 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
+[extras]
+flask = ["Flask"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<4.0"
-content-hash = "bd8afe638c4a4edc7f1777c07c444c37a841622b6773c9e6d68ffc1bf3570d36"
+content-hash = "8fa0e550d9d7dad7be5eeef6e58d543a1d0bb6e9f5ecfbee7cd5271ef2e41521"

--- a/poetry.lock
+++ b/poetry.lock
@@ -398,34 +398,34 @@ toml = ["tomli"]
 
 [[package]]
 name = "cryptography"
-version = "41.0.3"
+version = "41.0.4"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "cryptography-41.0.3-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:652627a055cb52a84f8c448185922241dd5217443ca194d5739b44612c5e6507"},
-    {file = "cryptography-41.0.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:8f09daa483aedea50d249ef98ed500569841d6498aa9c9f4b0531b9964658922"},
-    {file = "cryptography-41.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fd871184321100fb400d759ad0cddddf284c4b696568204d281c902fc7b0d81"},
-    {file = "cryptography-41.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84537453d57f55a50a5b6835622ee405816999a7113267739a1b4581f83535bd"},
-    {file = "cryptography-41.0.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3fb248989b6363906827284cd20cca63bb1a757e0a2864d4c1682a985e3dca47"},
-    {file = "cryptography-41.0.3-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:42cb413e01a5d36da9929baa9d70ca90d90b969269e5a12d39c1e0d475010116"},
-    {file = "cryptography-41.0.3-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:aeb57c421b34af8f9fe830e1955bf493a86a7996cc1338fe41b30047d16e962c"},
-    {file = "cryptography-41.0.3-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:6af1c6387c531cd364b72c28daa29232162010d952ceb7e5ca8e2827526aceae"},
-    {file = "cryptography-41.0.3-cp37-abi3-win32.whl", hash = "sha256:0d09fb5356f975974dbcb595ad2d178305e5050656affb7890a1583f5e02a306"},
-    {file = "cryptography-41.0.3-cp37-abi3-win_amd64.whl", hash = "sha256:a983e441a00a9d57a4d7c91b3116a37ae602907a7618b882c8013b5762e80574"},
-    {file = "cryptography-41.0.3-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5259cb659aa43005eb55a0e4ff2c825ca111a0da1814202c64d28a985d33b087"},
-    {file = "cryptography-41.0.3-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:67e120e9a577c64fe1f611e53b30b3e69744e5910ff3b6e97e935aeb96005858"},
-    {file = "cryptography-41.0.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:7efe8041897fe7a50863e51b77789b657a133c75c3b094e51b5e4b5cec7bf906"},
-    {file = "cryptography-41.0.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:ce785cf81a7bdade534297ef9e490ddff800d956625020ab2ec2780a556c313e"},
-    {file = "cryptography-41.0.3-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:57a51b89f954f216a81c9d057bf1a24e2f36e764a1ca9a501a6964eb4a6800dd"},
-    {file = "cryptography-41.0.3-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:4c2f0d35703d61002a2bbdcf15548ebb701cfdd83cdc12471d2bae80878a4207"},
-    {file = "cryptography-41.0.3-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:23c2d778cf829f7d0ae180600b17e9fceea3c2ef8b31a99e3c694cbbf3a24b84"},
-    {file = "cryptography-41.0.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:95dd7f261bb76948b52a5330ba5202b91a26fbac13ad0e9fc8a3ac04752058c7"},
-    {file = "cryptography-41.0.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:41d7aa7cdfded09b3d73a47f429c298e80796c8e825ddfadc84c8a7f12df212d"},
-    {file = "cryptography-41.0.3-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d0d651aa754ef58d75cec6edfbd21259d93810b73f6ec246436a21b7841908de"},
-    {file = "cryptography-41.0.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:ab8de0d091acbf778f74286f4989cf3d1528336af1b59f3e5d2ebca8b5fe49e1"},
-    {file = "cryptography-41.0.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a74fbcdb2a0d46fe00504f571a2a540532f4c188e6ccf26f1f178480117b33c4"},
-    {file = "cryptography-41.0.3.tar.gz", hash = "sha256:6d192741113ef5e30d89dcb5b956ef4e1578f304708701b8b73d38e3e1461f34"},
+    {file = "cryptography-41.0.4-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:80907d3faa55dc5434a16579952ac6da800935cd98d14dbd62f6f042c7f5e839"},
+    {file = "cryptography-41.0.4-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:35c00f637cd0b9d5b6c6bd11b6c3359194a8eba9c46d4e875a3660e3b400005f"},
+    {file = "cryptography-41.0.4-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cecfefa17042941f94ab54f769c8ce0fe14beff2694e9ac684176a2535bf9714"},
+    {file = "cryptography-41.0.4-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e40211b4923ba5a6dc9769eab704bdb3fbb58d56c5b336d30996c24fcf12aadb"},
+    {file = "cryptography-41.0.4-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:23a25c09dfd0d9f28da2352503b23e086f8e78096b9fd585d1d14eca01613e13"},
+    {file = "cryptography-41.0.4-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2ed09183922d66c4ec5fdaa59b4d14e105c084dd0febd27452de8f6f74704143"},
+    {file = "cryptography-41.0.4-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:5a0f09cefded00e648a127048119f77bc2b2ec61e736660b5789e638f43cc397"},
+    {file = "cryptography-41.0.4-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:9eeb77214afae972a00dee47382d2591abe77bdae166bda672fb1e24702a3860"},
+    {file = "cryptography-41.0.4-cp37-abi3-win32.whl", hash = "sha256:3b224890962a2d7b57cf5eeb16ccaafba6083f7b811829f00476309bce2fe0fd"},
+    {file = "cryptography-41.0.4-cp37-abi3-win_amd64.whl", hash = "sha256:c880eba5175f4307129784eca96f4e70b88e57aa3f680aeba3bab0e980b0f37d"},
+    {file = "cryptography-41.0.4-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:004b6ccc95943f6a9ad3142cfabcc769d7ee38a3f60fb0dddbfb431f818c3a67"},
+    {file = "cryptography-41.0.4-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:86defa8d248c3fa029da68ce61fe735432b047e32179883bdb1e79ed9bb8195e"},
+    {file = "cryptography-41.0.4-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:37480760ae08065437e6573d14be973112c9e6dcaf5f11d00147ee74f37a3829"},
+    {file = "cryptography-41.0.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:b5f4dfe950ff0479f1f00eda09c18798d4f49b98f4e2006d644b3301682ebdca"},
+    {file = "cryptography-41.0.4-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7e53db173370dea832190870e975a1e09c86a879b613948f09eb49324218c14d"},
+    {file = "cryptography-41.0.4-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5b72205a360f3b6176485a333256b9bcd48700fc755fef51c8e7e67c4b63e3ac"},
+    {file = "cryptography-41.0.4-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:93530900d14c37a46ce3d6c9e6fd35dbe5f5601bf6b3a5c325c7bffc030344d9"},
+    {file = "cryptography-41.0.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:efc8ad4e6fc4f1752ebfb58aefece8b4e3c4cae940b0994d43649bdfce8d0d4f"},
+    {file = "cryptography-41.0.4-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c3391bd8e6de35f6f1140e50aaeb3e2b3d6a9012536ca23ab0d9c35ec18c8a91"},
+    {file = "cryptography-41.0.4-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:0d9409894f495d465fe6fda92cb70e8323e9648af912d5b9141d616df40a87b8"},
+    {file = "cryptography-41.0.4-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:8ac4f9ead4bbd0bc8ab2d318f97d85147167a488be0e08814a37eb2f439d5cf6"},
+    {file = "cryptography-41.0.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:047c4603aeb4bbd8db2756e38f5b8bd7e94318c047cfe4efeb5d715e08b49311"},
+    {file = "cryptography-41.0.4.tar.gz", hash = "sha256:7febc3094125fc126a7f6fb1f420d0da639f3f32cb15c8ff0dc3997c4549f51a"},
 ]
 
 [package.dependencies]
@@ -556,13 +556,13 @@ dev = ["pyTest", "pyTest-cov"]
 
 [[package]]
 name = "flask"
-version = "2.3.2"
+version = "2.3.3"
 description = "A simple framework for building complex web applications."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Flask-2.3.2-py3-none-any.whl", hash = "sha256:77fd4e1249d8c9923de34907236b747ced06e5467ecac1a7bb7115ae0e9670b0"},
-    {file = "Flask-2.3.2.tar.gz", hash = "sha256:8c2f9abd47a9e8df7f0c3f091ce9497d011dc3b31effcf4c85a6e2b50f4114ef"},
+    {file = "flask-2.3.3-py3-none-any.whl", hash = "sha256:f69fcd559dc907ed196ab9df0e48471709175e696d6e698dd4dbe940f96ce66b"},
+    {file = "flask-2.3.3.tar.gz", hash = "sha256:09c347a92aa7ff4a8e7f3206795f30d826654baf38b873d0744cd571ca609efc"},
 ]
 
 [package.dependencies]
@@ -571,7 +571,7 @@ click = ">=8.1.3"
 importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
 itsdangerous = ">=2.1.2"
 Jinja2 = ">=3.1.2"
-Werkzeug = ">=2.3.3"
+Werkzeug = ">=2.3.7"
 
 [package.extras]
 async = ["asgiref (>=3.2)"]
@@ -1251,13 +1251,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.4"
+version = "2.0.5"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "urllib3-2.0.4-py3-none-any.whl", hash = "sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4"},
-    {file = "urllib3-2.0.4.tar.gz", hash = "sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11"},
+    {file = "urllib3-2.0.5-py3-none-any.whl", hash = "sha256:ef16afa8ba34a1f989db38e1dbbe0c302e4289a47856990d0682e374563ce35e"},
+    {file = "urllib3-2.0.5.tar.gz", hash = "sha256:13abf37382ea2ce6fb744d4dad67838eec857c9f4f57009891805e0b5e123594"},
 ]
 
 [package.extras]
@@ -1305,17 +1305,17 @@ watchdog = ["watchdog (>=2.3)"]
 
 [[package]]
 name = "zipp"
-version = "3.16.2"
+version = "3.17.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "zipp-3.16.2-py3-none-any.whl", hash = "sha256:679e51dd4403591b2d6838a48de3d283f3d188412a9782faadf845f298736ba0"},
-    {file = "zipp-3.16.2.tar.gz", hash = "sha256:ebc15946aa78bd63458992fc81ec3b6f7b1e92d51c35e6de1c3804e73b799147"},
+    {file = "zipp-3.17.0-py3-none-any.whl", hash = "sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"},
+    {file = "zipp-3.17.0.tar.gz", hash = "sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
 [extras]
@@ -1324,4 +1324,4 @@ flask = ["Flask"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<4.0"
-content-hash = "8fa0e550d9d7dad7be5eeef6e58d543a1d0bb6e9f5ecfbee7cd5271ef2e41521"
+content-hash = "6c53c15624d080b2c5caf095259aed6d328b3cb64ca0b72de57bd56450a2d9c4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ Flask = {version = ">=2", python = ">=3.8"}
 [tool.poetry.group.dev.dependencies]
 mock = "5.1.0"
 pre-commit = {version = "3.0.0", python = ">=3.8"}
-flake8 = {version = "6.0.0", python = ">=3.8.1"}
-flake8-pyproject = {version = "^1.2.3", python = ">=3.8.1"}
+flake8 = {version = "6.1.0", python = ">=3.8.1"}
+flake8-pyproject = {version = "1.2.3", python = ">=3.8.1"}
 flake8-bugbear = {version = "23.3.23", python = ">=3.8.1"}
 liccheck = "0.9.1"
 isort = {version = "5.12.0", python = ">=3.8"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ Flask = ["Flask"]
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
-requests = "2.31.0"
-pyjwt = {version = "2.8.0", extras = ["crypto"]}
-email-validator = "2.0.0.post2"
+requests = ">=2.27.0"
+pyjwt = {version = ">=2.4.0", extras = ["crypto"]}
+email-validator = ">=2,<3"
 liccheck = "^0.9.1"
 Flask = {version = ">=2", python = ">=3.8"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,12 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 packages = [
-    { include = "descope"},
+    { include = "descope" },
 ]
+
+[tool.poetry.extras]
+Flask = ["Flask"]
+
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/descope/python-sdk/issues"
@@ -36,11 +40,13 @@ requests = "2.31.0"
 pyjwt = {version = "2.8.0", extras = ["crypto"]}
 email-validator = "2.0.0.post2"
 liccheck = "^0.9.1"
+Flask = {version = "2.3.2", python = ">=3.8"}
 
 [tool.poetry.group.dev.dependencies]
 mock = "5.1.0"
 pre-commit = {version = "3.0.0", python = ">=3.8"}
 flake8 = {version = "6.0.0", python = ">=3.8.1"}
+flake8-pyproject = {version = "^1.2.3", python = ">=3.8.1"}
 flake8-bugbear = {version = "23.3.23", python = ">=3.8.1"}
 liccheck = "0.9.1"
 isort = {version = "5.12.0", python = ">=3.8"}
@@ -59,9 +65,6 @@ types-setuptools = "68.1.0.1"
 pytest = {version = "6.2.5", python = ">=3.8"}
 coverage = {version = "^7.3.1", python = ">=3.8", extras = ["toml"]}
 
-[tool.poetry.group.samples.dependencies]
-Flask = {version = "2.3.2", python = ">=3.8"}
-
 [build-system]
 requires = ["poetry-core>=1.1.0"]
 build-backend = "poetry.core.masonry.api"
@@ -71,7 +74,7 @@ relative_files = true
 source = ["descope"]
 
 [tool.coverage.report]
-fail_under = 96
+fail_under = 85
 skip_covered = true
 skip_empty = true
 
@@ -81,3 +84,4 @@ profile = "black"
 [tool.flake8]
 per-file-ignores = "__init__.py:F401"
 ignore = "E501,N818,W503"
+max-line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requests = "2.31.0"
 pyjwt = {version = "2.8.0", extras = ["crypto"]}
 email-validator = "2.0.0.post2"
 liccheck = "^0.9.1"
-Flask = {version = "2.3.2", python = ">=3.8"}
+Flask = {version = ">=2", python = ">=3.8"}
 
 [tool.poetry.group.dev.dependencies]
 mock = "5.1.0"
@@ -72,9 +72,13 @@ build-backend = "poetry.core.masonry.api"
 [tool.coverage.run]
 relative_files = true
 source = ["descope"]
+omit = [
+    "descope/flask/*",
+]
+
 
 [tool.coverage.report]
-fail_under = 85
+fail_under = 98
 skip_covered = true
 skip_empty = true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+blinker==1.6.2 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:4afd3de66ef3a9f8067559fb7a1cbe555c17dcbe15971b05d1b625c3e7abe213 \
+    --hash=sha256:c3d739772abb7bc2860abf5f2ec284223d9ad5c76da018234f6f50d6f31ab1f0
 certifi==2023.7.22 ; python_version >= "3.7" and python_version < "4.0" \
     --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082 \
     --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9
@@ -142,6 +145,12 @@ charset-normalizer==3.2.0 ; python_version >= "3.7" and python_version < "4.0" \
     --hash=sha256:f7560358a6811e52e9c4d142d497f1a6e10103d3a6881f18d04dbce3729c0e2c \
     --hash=sha256:f779d3ad205f108d14e99bb3859aa7dd8e9c68874617c72354d7ecaec2a054ac \
     --hash=sha256:f87f746ee241d30d6ed93969de31e5ffd09a2961a051e60ae6bddde9ec3583aa
+click==8.1.7 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28 \
+    --hash=sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de
+colorama==0.4.6 ; python_version >= "3.8" and python_version < "4.0" and platform_system == "Windows" \
+    --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
+    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
 configparser==5.3.0 ; python_version >= "3.7" and python_version < "4.0" \
     --hash=sha256:8be267824b541c09b08db124917f48ab525a6c3e837011f3130781a224c57090 \
     --hash=sha256:b065779fd93c6bf4cee42202fa4351b4bb842e96a3fb469440e484517a49b9fa
@@ -175,12 +184,75 @@ dnspython==2.3.0 ; python_version >= "3.7" and python_version < "4.0" \
 email-validator==2.0.0.post2 ; python_version >= "3.7" and python_version < "4.0" \
     --hash=sha256:1ff6e86044200c56ae23595695c54e9614f4a9551e0e393614f764860b3d7900 \
     --hash=sha256:2466ba57cda361fb7309fd3d5a225723c788ca4bbad32a0ebd5373b99730285c
+flask==2.3.2 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:77fd4e1249d8c9923de34907236b747ced06e5467ecac1a7bb7115ae0e9670b0 \
+    --hash=sha256:8c2f9abd47a9e8df7f0c3f091ce9497d011dc3b31effcf4c85a6e2b50f4114ef
 idna==3.4 ; python_version >= "3.7" and python_version < "4.0" \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \
     --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
+importlib-metadata==6.8.0 ; python_version >= "3.8" and python_version < "3.10" \
+    --hash=sha256:3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb \
+    --hash=sha256:dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743
+itsdangerous==2.1.2 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44 \
+    --hash=sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a
+jinja2==3.1.2 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852 \
+    --hash=sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61
 liccheck==0.9.1 ; python_version >= "3.7" and python_version < "4.0" \
     --hash=sha256:0efbca7d765264225f334461cffb152dee13fdbbcdfcb3604f7d40fdc661f695 \
     --hash=sha256:d41f7ca763688cbb5691ed70ab53cf4608dd68a331f2d672f3cf8799e45e88dd
+markupsafe==2.1.3 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e \
+    --hash=sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e \
+    --hash=sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431 \
+    --hash=sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686 \
+    --hash=sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559 \
+    --hash=sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc \
+    --hash=sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c \
+    --hash=sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0 \
+    --hash=sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4 \
+    --hash=sha256:338ae27d6b8745585f87218a3f23f1512dbf52c26c28e322dbe54bcede54ccb9 \
+    --hash=sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575 \
+    --hash=sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba \
+    --hash=sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d \
+    --hash=sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3 \
+    --hash=sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00 \
+    --hash=sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155 \
+    --hash=sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac \
+    --hash=sha256:65c1a9bcdadc6c28eecee2c119465aebff8f7a584dd719facdd9e825ec61ab52 \
+    --hash=sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f \
+    --hash=sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8 \
+    --hash=sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b \
+    --hash=sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24 \
+    --hash=sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea \
+    --hash=sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198 \
+    --hash=sha256:8758846a7e80910096950b67071243da3e5a20ed2546e6392603c096778d48e0 \
+    --hash=sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee \
+    --hash=sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be \
+    --hash=sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2 \
+    --hash=sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707 \
+    --hash=sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6 \
+    --hash=sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58 \
+    --hash=sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779 \
+    --hash=sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636 \
+    --hash=sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c \
+    --hash=sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad \
+    --hash=sha256:b076b6226fb84157e3f7c971a47ff3a679d837cf338547532ab866c57930dbee \
+    --hash=sha256:b7ff0f54cb4ff66dd38bebd335a38e2c22c41a8ee45aa608efc890ac3e3931bc \
+    --hash=sha256:bfce63a9e7834b12b87c64d6b155fdd9b3b96191b6bd334bf37db7ff1fe457f2 \
+    --hash=sha256:c011a4149cfbcf9f03994ec2edffcb8b1dc2d2aede7ca243746df97a5d41ce48 \
+    --hash=sha256:c9c804664ebe8f83a211cace637506669e7890fec1b4195b505c214e50dd4eb7 \
+    --hash=sha256:ca379055a47383d02a5400cb0d110cef0a776fc644cda797db0c5696cfd7e18e \
+    --hash=sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b \
+    --hash=sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa \
+    --hash=sha256:ceb01949af7121f9fc39f7d27f91be8546f3fb112c608bc4029aef0bab86a2a5 \
+    --hash=sha256:d080e0a5eb2529460b30190fcfcc4199bd7f827663f858a226a81bc27beaa97e \
+    --hash=sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb \
+    --hash=sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9 \
+    --hash=sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57 \
+    --hash=sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc \
+    --hash=sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2
 pycparser==2.21 ; python_version >= "3.7" and python_version < "4.0" \
     --hash=sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9 \
     --hash=sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206
@@ -202,3 +274,9 @@ typing-extensions==4.7.1 ; python_version == "3.7" \
 urllib3==2.0.4 ; python_version >= "3.7" and python_version < "4.0" \
     --hash=sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11 \
     --hash=sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4
+werkzeug==2.3.7 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:2b8c0e447b4b9dbcc85dd97b6eeb4dcbaf6c8b6c3be0bd654e25553e0a2157d8 \
+    --hash=sha256:effc12dba7f3bd72e605ce49807bbe692bd729c3bb122a3b91747a6ae77df528
+zipp==3.16.2 ; python_version >= "3.8" and python_version < "3.10" \
+    --hash=sha256:679e51dd4403591b2d6838a48de3d283f3d188412a9782faadf845f298736ba0 \
+    --hash=sha256:ebc15946aa78bd63458992fc81ec3b6f7b1e92d51c35e6de1c3804e73b799147

--- a/requirements.txt
+++ b/requirements.txt
@@ -154,39 +154,39 @@ colorama==0.4.6 ; python_version >= "3.8" and python_version < "4.0" and platfor
 configparser==5.3.0 ; python_version >= "3.7" and python_version < "4.0" \
     --hash=sha256:8be267824b541c09b08db124917f48ab525a6c3e837011f3130781a224c57090 \
     --hash=sha256:b065779fd93c6bf4cee42202fa4351b4bb842e96a3fb469440e484517a49b9fa
-cryptography==41.0.3 ; python_version >= "3.7" and python_version < "4.0" \
-    --hash=sha256:0d09fb5356f975974dbcb595ad2d178305e5050656affb7890a1583f5e02a306 \
-    --hash=sha256:23c2d778cf829f7d0ae180600b17e9fceea3c2ef8b31a99e3c694cbbf3a24b84 \
-    --hash=sha256:3fb248989b6363906827284cd20cca63bb1a757e0a2864d4c1682a985e3dca47 \
-    --hash=sha256:41d7aa7cdfded09b3d73a47f429c298e80796c8e825ddfadc84c8a7f12df212d \
-    --hash=sha256:42cb413e01a5d36da9929baa9d70ca90d90b969269e5a12d39c1e0d475010116 \
-    --hash=sha256:4c2f0d35703d61002a2bbdcf15548ebb701cfdd83cdc12471d2bae80878a4207 \
-    --hash=sha256:4fd871184321100fb400d759ad0cddddf284c4b696568204d281c902fc7b0d81 \
-    --hash=sha256:5259cb659aa43005eb55a0e4ff2c825ca111a0da1814202c64d28a985d33b087 \
-    --hash=sha256:57a51b89f954f216a81c9d057bf1a24e2f36e764a1ca9a501a6964eb4a6800dd \
-    --hash=sha256:652627a055cb52a84f8c448185922241dd5217443ca194d5739b44612c5e6507 \
-    --hash=sha256:67e120e9a577c64fe1f611e53b30b3e69744e5910ff3b6e97e935aeb96005858 \
-    --hash=sha256:6af1c6387c531cd364b72c28daa29232162010d952ceb7e5ca8e2827526aceae \
-    --hash=sha256:6d192741113ef5e30d89dcb5b956ef4e1578f304708701b8b73d38e3e1461f34 \
-    --hash=sha256:7efe8041897fe7a50863e51b77789b657a133c75c3b094e51b5e4b5cec7bf906 \
-    --hash=sha256:84537453d57f55a50a5b6835622ee405816999a7113267739a1b4581f83535bd \
-    --hash=sha256:8f09daa483aedea50d249ef98ed500569841d6498aa9c9f4b0531b9964658922 \
-    --hash=sha256:95dd7f261bb76948b52a5330ba5202b91a26fbac13ad0e9fc8a3ac04752058c7 \
-    --hash=sha256:a74fbcdb2a0d46fe00504f571a2a540532f4c188e6ccf26f1f178480117b33c4 \
-    --hash=sha256:a983e441a00a9d57a4d7c91b3116a37ae602907a7618b882c8013b5762e80574 \
-    --hash=sha256:ab8de0d091acbf778f74286f4989cf3d1528336af1b59f3e5d2ebca8b5fe49e1 \
-    --hash=sha256:aeb57c421b34af8f9fe830e1955bf493a86a7996cc1338fe41b30047d16e962c \
-    --hash=sha256:ce785cf81a7bdade534297ef9e490ddff800d956625020ab2ec2780a556c313e \
-    --hash=sha256:d0d651aa754ef58d75cec6edfbd21259d93810b73f6ec246436a21b7841908de
+cryptography==41.0.4 ; python_version >= "3.7" and python_version < "4.0" \
+    --hash=sha256:004b6ccc95943f6a9ad3142cfabcc769d7ee38a3f60fb0dddbfb431f818c3a67 \
+    --hash=sha256:047c4603aeb4bbd8db2756e38f5b8bd7e94318c047cfe4efeb5d715e08b49311 \
+    --hash=sha256:0d9409894f495d465fe6fda92cb70e8323e9648af912d5b9141d616df40a87b8 \
+    --hash=sha256:23a25c09dfd0d9f28da2352503b23e086f8e78096b9fd585d1d14eca01613e13 \
+    --hash=sha256:2ed09183922d66c4ec5fdaa59b4d14e105c084dd0febd27452de8f6f74704143 \
+    --hash=sha256:35c00f637cd0b9d5b6c6bd11b6c3359194a8eba9c46d4e875a3660e3b400005f \
+    --hash=sha256:37480760ae08065437e6573d14be973112c9e6dcaf5f11d00147ee74f37a3829 \
+    --hash=sha256:3b224890962a2d7b57cf5eeb16ccaafba6083f7b811829f00476309bce2fe0fd \
+    --hash=sha256:5a0f09cefded00e648a127048119f77bc2b2ec61e736660b5789e638f43cc397 \
+    --hash=sha256:5b72205a360f3b6176485a333256b9bcd48700fc755fef51c8e7e67c4b63e3ac \
+    --hash=sha256:7e53db173370dea832190870e975a1e09c86a879b613948f09eb49324218c14d \
+    --hash=sha256:7febc3094125fc126a7f6fb1f420d0da639f3f32cb15c8ff0dc3997c4549f51a \
+    --hash=sha256:80907d3faa55dc5434a16579952ac6da800935cd98d14dbd62f6f042c7f5e839 \
+    --hash=sha256:86defa8d248c3fa029da68ce61fe735432b047e32179883bdb1e79ed9bb8195e \
+    --hash=sha256:8ac4f9ead4bbd0bc8ab2d318f97d85147167a488be0e08814a37eb2f439d5cf6 \
+    --hash=sha256:93530900d14c37a46ce3d6c9e6fd35dbe5f5601bf6b3a5c325c7bffc030344d9 \
+    --hash=sha256:9eeb77214afae972a00dee47382d2591abe77bdae166bda672fb1e24702a3860 \
+    --hash=sha256:b5f4dfe950ff0479f1f00eda09c18798d4f49b98f4e2006d644b3301682ebdca \
+    --hash=sha256:c3391bd8e6de35f6f1140e50aaeb3e2b3d6a9012536ca23ab0d9c35ec18c8a91 \
+    --hash=sha256:c880eba5175f4307129784eca96f4e70b88e57aa3f680aeba3bab0e980b0f37d \
+    --hash=sha256:cecfefa17042941f94ab54f769c8ce0fe14beff2694e9ac684176a2535bf9714 \
+    --hash=sha256:e40211b4923ba5a6dc9769eab704bdb3fbb58d56c5b336d30996c24fcf12aadb \
+    --hash=sha256:efc8ad4e6fc4f1752ebfb58aefece8b4e3c4cae940b0994d43649bdfce8d0d4f
 dnspython==2.3.0 ; python_version >= "3.7" and python_version < "4.0" \
     --hash=sha256:224e32b03eb46be70e12ef6d64e0be123a64e621ab4c0822ff6d450d52a540b9 \
     --hash=sha256:89141536394f909066cabd112e3e1a37e4e654db00a25308b0f130bc3152eb46
 email-validator==2.0.0.post2 ; python_version >= "3.7" and python_version < "4.0" \
     --hash=sha256:1ff6e86044200c56ae23595695c54e9614f4a9551e0e393614f764860b3d7900 \
     --hash=sha256:2466ba57cda361fb7309fd3d5a225723c788ca4bbad32a0ebd5373b99730285c
-flask==2.3.2 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:77fd4e1249d8c9923de34907236b747ced06e5467ecac1a7bb7115ae0e9670b0 \
-    --hash=sha256:8c2f9abd47a9e8df7f0c3f091ce9497d011dc3b31effcf4c85a6e2b50f4114ef
+flask==2.3.3 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:09c347a92aa7ff4a8e7f3206795f30d826654baf38b873d0744cd571ca609efc \
+    --hash=sha256:f69fcd559dc907ed196ab9df0e48471709175e696d6e698dd4dbe940f96ce66b
 idna==3.4 ; python_version >= "3.7" and python_version < "4.0" \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \
     --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
@@ -271,12 +271,12 @@ toml==0.10.2 ; python_version >= "3.7" and python_version < "4.0" \
 typing-extensions==4.7.1 ; python_version == "3.7" \
     --hash=sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36 \
     --hash=sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2
-urllib3==2.0.4 ; python_version >= "3.7" and python_version < "4.0" \
-    --hash=sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11 \
-    --hash=sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4
+urllib3==2.0.5 ; python_version >= "3.7" and python_version < "4.0" \
+    --hash=sha256:13abf37382ea2ce6fb744d4dad67838eec857c9f4f57009891805e0b5e123594 \
+    --hash=sha256:ef16afa8ba34a1f989db38e1dbbe0c302e4289a47856990d0682e374563ce35e
 werkzeug==2.3.7 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:2b8c0e447b4b9dbcc85dd97b6eeb4dcbaf6c8b6c3be0bd654e25553e0a2157d8 \
     --hash=sha256:effc12dba7f3bd72e605ce49807bbe692bd729c3bb122a3b91747a6ae77df528
-zipp==3.16.2 ; python_version >= "3.8" and python_version < "3.10" \
-    --hash=sha256:679e51dd4403591b2d6838a48de3d283f3d188412a9782faadf845f298736ba0 \
-    --hash=sha256:ebc15946aa78bd63458992fc81ec3b6f7b1e92d51c35e6de1c3804e73b799147
+zipp==3.17.0 ; python_version >= "3.8" and python_version < "3.10" \
+    --hash=sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31 \
+    --hash=sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0

--- a/samples/flask_authentication.py
+++ b/samples/flask_authentication.py
@@ -1,12 +1,7 @@
 from flask import Flask, Response
 
 from descope import DescopeClient
-
-from .decorators.flask_decorators import (
-    descope_full_login,
-    descope_logout,
-    descope_validate_auth,
-)
+from descope.flask import descope_full_login, descope_logout, descope_validate_auth
 
 APP = Flask(__name__)
 PROJECT_ID = ""  # Can be set also by environment variable

--- a/samples/magiclink_web_sample_app.py
+++ b/samples/magiclink_web_sample_app.py
@@ -1,11 +1,14 @@
 from flask import Flask, Response, _request_ctx_stack, jsonify, request
 
-from descope import AuthException, DeliveryMethod, DescopeClient
-
-from .decorators.flask_decorators import (
+from descope import (
     COOKIE_DATA_NAME,
     REFRESH_SESSION_TOKEN_NAME,
     SESSION_TOKEN_NAME,
+    AuthException,
+    DeliveryMethod,
+    DescopeClient,
+)
+from descope.flask import (
     descope_logout,
     descope_validate_auth,
     descope_verify_magiclink_token,

--- a/samples/oauth_web_sample_app.py
+++ b/samples/oauth_web_sample_app.py
@@ -1,12 +1,7 @@
 from flask import Flask, jsonify
 
 from descope import DescopeClient
-
-from .decorators.flask_decorators import (
-    descope_logout,
-    descope_oauth,
-    descope_validate_auth,
-)
+from descope.flask import descope_logout, descope_oauth, descope_validate_auth
 
 APP = Flask(__name__)
 

--- a/samples/otp_web_sample_app.py
+++ b/samples/otp_web_sample_app.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 
 from flask import Flask, Response, jsonify, request
@@ -13,6 +12,7 @@ from descope import (
     DeliveryMethod,
     DescopeClient,
 )
+from descope.flask import set_cookie_on_response
 
 APP = Flask(__name__)
 
@@ -20,27 +20,6 @@ PROJECT_ID = ""
 
 # init the DescopeClient
 descope_client = DescopeClient(PROJECT_ID, skip_verify=True)
-
-
-def set_cookie_on_response(response: Response, token: dict, cookie_data: dict):
-    cookie_domain = cookie_data.get("domain", "")
-    if cookie_domain == "":
-        cookie_domain = None
-
-    current_time = datetime.datetime.now()
-    expire_time = current_time + datetime.timedelta(days=30)
-
-    return response.set_cookie(
-        key=token.get("drn", ""),
-        value=token.get("jwt", ""),
-        max_age=cookie_data.get("maxAge", int(expire_time.timestamp())),
-        expires=cookie_data.get("exp", expire_time),
-        path=cookie_data.get("path", "/"),
-        domain=cookie_domain,
-        secure=False,  # True
-        httponly=True,
-        samesite="Strict",  # "Strict", "Lax", "None"
-    )
 
 
 class Error(Exception):

--- a/samples/password_web_sample_app.py
+++ b/samples/password_web_sample_app.py
@@ -1,5 +1,3 @@
-import datetime
-
 from flask import Flask, Response, jsonify, request
 
 from descope import (
@@ -10,6 +8,7 @@ from descope import (
     AuthException,
     DescopeClient,
 )
+from descope.flask import set_cookie_on_response
 
 APP = Flask(__name__)
 
@@ -17,27 +16,6 @@ PROJECT_ID = ""
 
 # init the DescopeClient
 descope_client = DescopeClient(PROJECT_ID, skip_verify=True)
-
-
-def set_cookie_on_response(response: Response, token: dict, cookie_data: dict):
-    cookie_domain = cookie_data.get("domain", "")
-    if cookie_domain == "":
-        cookie_domain = None
-
-    current_time = datetime.datetime.now()
-    expire_time = current_time + datetime.timedelta(days=30)
-
-    return response.set_cookie(
-        key=token.get("drn", ""),
-        value=token.get("jwt", ""),
-        max_age=cookie_data.get("maxAge", int(expire_time.timestamp())),
-        expires=cookie_data.get("exp", expire_time),
-        path=cookie_data.get("path", "/"),
-        domain=cookie_domain,
-        secure=False,  # True
-        httponly=True,
-        samesite="Strict",  # "Strict", "Lax", "None"
-    )
 
 
 class Error(Exception):


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/2539

## Description

Making flask an extra package of descope python-sdk
Extra means it is not installed by default, and only when adding the extra flag it will also install Flask dependencies that are needed.

* Adjusted the sample scripts to work with the package itself
* Added typing annotations
* Reduced test coverage of the new code
* Also added vscode settings and recommended extensions for ease development 
* Removed tox from pre-commit as it's a huge overhead for every commit, devs should test locally before committing, and tests still run in CI still.

