### PR TITLE
fix(ci): do not run coverage on schedule workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           path: .coverage.${{ matrix.py }}
 
   coverage:
+    if: github.event_name != 'schedule'
     name: Coverage
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
fixes an issue where scheduled workflows fail on coverage, remove this job as it's not needed for scheduled checks