### PR TITLE
fix: allow getting project_id from env

### DIFF
--- a/descope/auth.py
+++ b/descope/auth.py
@@ -64,8 +64,8 @@ class Auth:
 
     def __init__(
         self,
-        project_id: str,
-        public_key: dict | str | None,
+        project_id: str | None = None,
+        public_key: dict | str | None = None,
         skip_verify: bool = False,
         management_key: str | None = None,
         timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,5 @@
 import json
+import os
 import unittest
 from enum import Enum
 from unittest import mock
@@ -122,6 +123,14 @@ class TestAuth(common.DescopeTest):
             mock_get.return_value.ok = True
             mock_get.return_value.text = valid_keys_response
             self.assertIsNone(auth._fetch_public_keys())
+
+    def test_project_id_from_env(self):
+        os.environ["DESCOPE_PROJECT_ID"] = self.dummy_project_id
+        Auth()
+
+    def test_project_id_from_env_without_env(self):
+        os.environ["DESCOPE_PROJECT_ID"] = ""
+        self.assertRaises(AuthException, Auth)
 
     def test_verify_delivery_method(self):
         self.assertEqual(


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/4322

## Description

Allow using only env vars for configuration

## Must

- [x] Tests
- [ ] Documentation (if applicable)
