### PR TITLE
Add user history support for auth and mgmt apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ These sections show how to use the SDK to perform various authentication/authori
 9. [Roles & Permission Validation](#roles--permission-validation)
 10. [Tenant selection](#tenant-selection)
 11. [Logging Out](#logging-out)
+12. [History](#history)
 
 ## API Managment Function
 
@@ -371,7 +372,7 @@ jwt_response = descope_client.validate_and_refresh_session(session_token, refres
 
 Choose the right session validation and refresh combination that suits your needs.
 
-Note: all those validation apis can receive an optional 'audience' parameter that should be provided when using jwt that has the 'aud' claim)
+Note: all those validation apis can receive an optional 'audience' parameter that should be provided when using jwt that has the 'aud' claim.
 
 Refreshed sessions return the same response as is returned when users first sign up / log in,
 containing the session and refresh tokens, as well as all of the JWT claims.
@@ -467,6 +468,16 @@ invalidate all user's refresh tokens. After calling this function, you must inva
 
 ```python
 descope_client.logout_all(refresh_token)
+```
+
+### History
+You can get the current session user history.
+The request requires a valid refresh token.
+
+```python
+users_history_resp = descope_client.history(refresh_token)
+for user_history in users_history_resp:
+    # Do something
 ```
 
 ## Management API
@@ -647,6 +658,11 @@ descope_client.mgmt.user.logout_user_by_user_id("<user-id>")
 users_resp = descope_client.mgmt.user.search_all(tenant_ids=["my-tenant-id"])
 users = users_resp["users"]
     for user in users:
+        # Do something
+
+# Get users' authentication history
+users_history_resp = descope_client.mgmt.user.history(["user-id-1", "user-id-2"])
+    for user_history in users_history_resp:
         # Do something
 ```
 

--- a/descope/auth.py
+++ b/descope/auth.py
@@ -132,7 +132,11 @@ class Auth:
         return response
 
     def do_post(
-        self, uri: str, body: dict | None, params=None, pswd: str | None = None
+        self,
+        uri: str,
+        body: dict | list[dict] | list[str] | None,
+        params=None,
+        pswd: str | None = None,
     ) -> requests.Response:
         response = requests.post(
             f"{self.base_url}{uri}",

--- a/descope/common.py
+++ b/descope/common.py
@@ -24,6 +24,7 @@ class EndpointsV1:
     logout_path = "/v1/auth/logout"
     logout_all_path = "/v1/auth/logoutall"
     me_path = "/v1/auth/me"
+    history_path = "/v1/auth/me/history"
 
     # accesskey
     exchange_auth_access_key_path = "/v1/auth/accesskey/exchange"

--- a/descope/descope_client.py
+++ b/descope/descope_client.py
@@ -435,6 +435,41 @@ class DescopeClient:
         )
         return response.json()
 
+    def history(self, refresh_token: str) -> list[dict]:
+        """
+        Retrieve user authentication history for the refresh token
+
+        Args:
+        refresh_token (str): The refresh token
+
+        Return value (List[dict]):
+        Return List in the format
+             [
+                {
+                    "userId": "User's ID",
+                    "loginTime": "User'sLogin time",
+                    "city": "User's city",
+                    "country": "User's country",
+                    "ip": User's IP
+                }
+            ]
+
+        Raise:
+        AuthException: Exception is raised if session is not authorized or another error occurs
+        """
+        if refresh_token is None:
+            raise AuthException(
+                400,
+                ERROR_TYPE_INVALID_ARGUMENT,
+                f"signed refresh token {refresh_token} is empty",
+            )
+
+        uri = EndpointsV1.history_path
+        response = self._auth.do_get(
+            uri=uri, params=None, allow_redirects=None, pswd=refresh_token
+        )
+        return response.json()
+
     def exchange_access_key(
         self, access_key: str, audience: str | Iterable[str] | None = None
     ) -> dict:

--- a/descope/management/common.py
+++ b/descope/management/common.py
@@ -51,6 +51,7 @@ class MgmtV1:
     user_generate_magic_link_for_test_path = "/v1/mgmt/tests/generate/magiclink"
     user_generate_enchanted_link_for_test_path = "/v1/mgmt/tests/generate/enchantedlink"
     user_generate_embedded_link_path = "/v1/mgmt/user/signin/embeddedlink"
+    user_history_path = "/v1/mgmt/user/history"
 
     # access key
     access_key_create_path = "/v1/mgmt/accesskey/create"

--- a/descope/management/user.py
+++ b/descope/management/user.py
@@ -4,7 +4,6 @@ from descope._auth_base import AuthBase
 from descope.auth import Auth
 from descope.common import DeliveryMethod, LoginOptions
 from descope.exceptions import ERROR_TYPE_INVALID_ARGUMENT, AuthException
-from descope.management.user_pwd import UserPassword
 from descope.management.common import (
     AssociatedTenant,
     MgmtV1,
@@ -12,6 +11,7 @@ from descope.management.common import (
     associated_tenants_to_dict,
     sort_to_dict,
 )
+from descope.management.user_pwd import UserPassword
 
 
 class UserObj:
@@ -1366,6 +1366,35 @@ class User(AuthBase):
             pswd=self._auth.management_key,
         )
         return response.json()["token"]
+
+    def history(self, user_ids: List[str]) -> List[dict]:
+        """
+        Retrieve users' authentication history, by the given user's ids.
+
+        Args:
+        login_ids (List[str]): List of Users' IDs.
+
+        Return value (List[dict]):
+        Return List in the format
+             [
+                {
+                    "userId": "User's ID",
+                    "loginTime": "User'sLogin time",
+                    "city": "User's city",
+                    "country": "User's country",
+                    "ip": User's IP
+                }
+            ]
+
+        Raise:
+        AuthException: raised if the operation fails
+        """
+        response = self._auth.do_post(
+            MgmtV1.user_history_path,
+            user_ids,
+            pswd=self._auth.management_key,
+        )
+        return response.json()
 
     @staticmethod
     def _compose_create_body(

--- a/tests/management/test_user.py
+++ b/tests/management/test_user.py
@@ -9,9 +9,9 @@ from descope.management.user import UserObj
 from descope.management.user_pwd import (
     UserPassword,
     UserPasswordBcrypt,
+    UserPasswordDjango,
     UserPasswordFirebase,
     UserPasswordPbkdf2,
-    UserPasswordDjango,
 )
 
 from .. import common
@@ -1865,6 +1865,72 @@ class TestUser(common.DescopeTest):
                     "loginId": "login-id",
                     "customClaims": {"k1": "v1"},
                 },
+                allow_redirects=False,
+                verify=True,
+                params=None,
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+
+    def test_history(self):
+        # Test failed flows
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = False
+            self.assertRaises(
+                AuthException, self.client.mgmt.user.history, ["user-id-1", "user-id-2"]
+            )
+
+        # Test success flow
+        with patch("requests.post") as mock_post:
+            network_resp = mock.Mock()
+            network_resp.ok = True
+            network_resp.json.return_value = json.loads(
+                """
+                [
+                    {
+                        "userId":    "kuku",
+                        "city":      "kefar saba",
+                        "country":   "Israel",
+                        "ip":        "1.1.1.1",
+                        "loginTime": 32
+                    },
+                    {
+                        "userId":    "nunu",
+                        "city":      "eilat",
+                        "country":   "Israele",
+                        "ip":        "1.1.1.2",
+                        "loginTime": 23
+                    }
+                ]
+                """
+            )
+            mock_post.return_value = network_resp
+            resp = self.client.mgmt.user.history(["user-id-1", "user-id-2"])
+            self.assertEqual(
+                resp,
+                [
+                    {
+                        "userId": "kuku",
+                        "city": "kefar saba",
+                        "country": "Israel",
+                        "ip": "1.1.1.1",
+                        "loginTime": 32,
+                    },
+                    {
+                        "userId": "nunu",
+                        "city": "eilat",
+                        "country": "Israele",
+                        "ip": "1.1.1.2",
+                        "loginTime": 23,
+                    },
+                ],
+            )
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.user_history_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                },
+                json=["user-id-1", "user-id-2"],
                 allow_redirects=False,
                 verify=True,
                 params=None,


### PR DESCRIPTION
## Description
Fixes https://github.com/descope/etc/issues/4713

Add user history support for auth and mgmt apis.

## Must
- [x] Tests
- [x] Documentation (if applicable)
