### PR TITLE
Remove redundant redirectUrl param

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,6 +794,7 @@ settings = SSOOIDCSettings(
 	name="myProvider",
 	client_id="myId",
 	client_secret="secret",
+    redirect_url="https://your.domain.com",
 	auth_url="https://dummy.com/auth",
 	token_url="https://dummy.com/token",
 	user_data_url="https://dummy.com/userInfo",
@@ -815,7 +816,6 @@ settings = SSOOIDCSettings(
 descope_client.mgmt.sso.configure_oidc_settings(
 	tenant_id, # Which tenant this configuration is for
 	settings, # The OIDC provider settings
-	redirect_url="https://your.domain.com", # Global redirection after successful authentication
     domains=["tenant-users.com"] # Users authentication with these domains will be logged in to this tenant
 )
 

--- a/descope/management/sso_settings.py
+++ b/descope/management/sso_settings.py
@@ -195,7 +195,6 @@ class SSOSettings(AuthBase):
         self,
         tenant_id: str,
         settings: SSOOIDCSettings,
-        redirect_url: Optional[str] = None,
         domains: Optional[List[str]] = None,
     ):
         """
@@ -204,7 +203,6 @@ class SSOSettings(AuthBase):
         Args:
         tenant_id (str): The tenant ID to be configured
         settings (SSOOIDCSettings): The OIDC settings to be configured for this tenant (all settings parameters are required).
-        redirect_url (str): Optional, the Redirect URL to use after successful authentication, or empty string to reset it (if not given it has to be set when starting an SSO authentication via the request).
         domains (List[str]): Optional,domains used to associate users authenticating via SSO with this tenant. Use empty list or None to reset them.
 
         Raise:
@@ -214,7 +212,7 @@ class SSOSettings(AuthBase):
         self._auth.do_post(
             MgmtV1.sso_configure_oidc_settings,
             SSOSettings._compose_configure_oidc_settings_body(
-                tenant_id, settings, redirect_url, domains
+                tenant_id, settings, domains
             ),
             pswd=self._auth.management_key,
         )
@@ -475,7 +473,6 @@ class SSOSettings(AuthBase):
     def _compose_configure_oidc_settings_body(
         tenant_id: str,
         settings: SSOOIDCSettings,
-        redirect_url: Optional[str],
         domains: Optional[List[str]],
     ) -> dict:
         attr_mapping = None
@@ -513,7 +510,6 @@ class SSOSettings(AuthBase):
                 "grantType": settings.grant_type,
                 "issuer": settings.issuer,
             },
-            "redirectUrl": redirect_url,
             "domains": domains,
         }
 

--- a/tests/management/test_sso_settings.py
+++ b/tests/management/test_sso_settings.py
@@ -132,7 +132,6 @@ class TestSSOSettings(common.DescopeTest):
                     name="myName",
                     client_id="cid",
                 ),
-                "https://redirect.com",
                 ["domain.com"],
             )
 
@@ -165,7 +164,6 @@ class TestSSOSettings(common.DescopeTest):
                             picture="picture",
                         ),
                     ),
-                    "https://redirect.com",
                     ["domain.com"],
                 )
             )
@@ -207,7 +205,6 @@ class TestSSOSettings(common.DescopeTest):
                             "picture": "picture",
                         },
                     },
-                    "redirectUrl": "https://redirect.com",
                     "domains": ["domain.com"],
                 },
                 allow_redirects=False,


### PR DESCRIPTION
Remove redundant redirectUrl function parameter so it will not be confused with the same redirectUrl parameter inside the OIDCSettings parameter.