### PR TITLE
Add force refresh and get refresh token options in get provider token

### DIFF
--- a/descope/management/user.py
+++ b/descope/management/user.py
@@ -606,6 +606,8 @@ class User(AuthBase):
         self,
         login_id: str,
         provider: str,
+        withRefreshToken: Optional[bool] = False,
+        forceRefresh: Optional[bool] = False,
     ) -> dict:
         """
         Get the provider token for the given login ID.
@@ -615,6 +617,8 @@ class User(AuthBase):
         Args:
         login_id (str): The login ID of the user.
         provider (str): The provider name (google, facebook, etc').
+        withRefreshToken (bool): Optional, set to true to get also the refresh token.
+        forceRefresh (bool): Optional, set to true to force refresh the token.
 
         Return value (dict):
         Return dict in the format
@@ -626,7 +630,7 @@ class User(AuthBase):
         """
         response = self._auth.do_get(
             MgmtV1.user_get_provider_token,
-            {"loginId": login_id, "provider": provider},
+            {"loginId": login_id, "provider": provider, "withRefreshToken": withRefreshToken, "forceRefresh": forceRefresh},
             pswd=self._auth.management_key,
         )
         return response.json()

--- a/tests/management/test_user.py
+++ b/tests/management/test_user.py
@@ -883,7 +883,7 @@ class TestUser(common.DescopeTest):
                 """{"provider": "p1", "providerUserId": "puid", "accessToken": "access123", "expiration": "123123123", "scopes": ["s1", "s2"]}"""
             )
             mock_get.return_value = network_resp
-            resp = self.client.mgmt.user.get_provider_token("valid-id", "p1")
+            resp = self.client.mgmt.user.get_provider_token("valid-id", "p1", True, True)
             self.assertEqual(resp["provider"], "p1")
             self.assertEqual(resp["providerUserId"], "puid")
             self.assertEqual(resp["accessToken"], "access123")
@@ -895,7 +895,7 @@ class TestUser(common.DescopeTest):
                     **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
-                params={"loginId": "valid-id", "provider": "p1"},
+                params={"loginId": "valid-id", "provider": "p1", "withRefreshToken": True, "forceRefresh": True},
                 allow_redirects=None,
                 verify=True,
                 timeout=DEFAULT_TIMEOUT_SECONDS,

--- a/tests/management/test_user.py
+++ b/tests/management/test_user.py
@@ -880,13 +880,14 @@ class TestUser(common.DescopeTest):
             network_resp = mock.Mock()
             network_resp.ok = True
             network_resp.json.return_value = json.loads(
-                """{"provider": "p1", "providerUserId": "puid", "accessToken": "access123", "expiration": "123123123", "scopes": ["s1", "s2"]}"""
+                """{"provider": "p1", "providerUserId": "puid", "accessToken": "access123", "refreshToken": "refresh456", "expiration": "123123123", "scopes": ["s1", "s2"]}"""
             )
             mock_get.return_value = network_resp
             resp = self.client.mgmt.user.get_provider_token("valid-id", "p1", True, True)
             self.assertEqual(resp["provider"], "p1")
             self.assertEqual(resp["providerUserId"], "puid")
             self.assertEqual(resp["accessToken"], "access123")
+            self.assertEqual(resp["refreshToken"], "refresh456")
             self.assertEqual(resp["expiration"], "123123123")
             self.assertEqual(resp["scopes"], ["s1", "s2"])
             mock_get.assert_called_with(


### PR DESCRIPTION
## Related Issues

Related to https://github.com/descope/etc/issues/6852

## Description
Support forcing refresh token in get provider token
Support getting the refresh token as part of the get provider token response

## Must

- [x] Tests
- [ ] Documentation (if applicable)
