### PR TITLE
add description field to accessKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,6 +703,7 @@ You can create, update, delete or load access keys, as well as search according 
 # Roles should be set directly if no tenants exist, otherwise set
 # on a per-tenant basis.
 # If user_id is supplied, then authorization would be ignored, and access key would be bound to the users authorization.
+# If description is supplied, then the access key will hold a descriptive text.
 # If permitted_ips is supplied, then the access key can only be used from that list of IP addresses or CIDR ranges
 create_resp = descope_client.mgmt.access_key.create(
     name="name",
@@ -710,6 +711,7 @@ create_resp = descope_client.mgmt.access_key.create(
     key_tenants=[
         AssociatedTenant("my-tenant-id", ["role-name1"]),
     ],
+    description="this is my access key",
     permitted_ips=['10.0.0.1', '192.168.1.0/24'],
 )
 key = create_resp["key"]

--- a/descope/management/access_key.py
+++ b/descope/management/access_key.py
@@ -131,7 +131,7 @@ class AccessKey(AuthBase):
         Args:
         id (str): The id of the access key to update.
         name (str): The updated access key name.
-        description (str): The description of the access key to update. (If not provided, will not be override)
+        description (str): The description of the access key to update. If not provided, it will not be overriden.
 
         Raise:
         AuthException: raised if update operation fails

--- a/descope/management/access_key.py
+++ b/descope/management/access_key.py
@@ -17,7 +17,7 @@ class AccessKey(AuthBase):
         key_tenants: Optional[List[AssociatedTenant]] = None,
         user_id: Optional[str] = None,
         custom_claims: Optional[dict] = None,
-        description: str = "",
+        description: Optional[str] = None,
         permitted_ips: Optional[List[str]] = None,
     ) -> dict:
         """
@@ -33,7 +33,7 @@ class AccessKey(AuthBase):
         user_id (str): Bind access key to this user id
             If user_id is supplied, then authorizations will be ignored, and the access key will be bound to the user's authorization.
         custom_claims (dict): Optional, map of claims and their values that will be present in the JWT.
-        description: an optional text the access key can hold.
+        description (str): an optional text the access key can hold.
         permitted_ips: (List[str]): An optional list of IP addresses or CIDR ranges that are allowed to use the access key.
 
         Return value (dict):
@@ -123,16 +123,15 @@ class AccessKey(AuthBase):
         self,
         id: str,
         name: str,
-        description: str = "",
+        description: Optional[str] = None,
     ):
         """
-        Update an existing access key with the given various fields. IMPORTANT: All parameters are used as overrides
-        to the existing access key. Empty fields will override populated fields. Use carefully.
+        Update an existing access key with the given various fields. IMPORTANT: id and name are mandatory fields.
 
         Args:
         id (str): The id of the access key to update.
         name (str): The updated access key name.
-        description(str): The description of the access key to update.
+        description (str): The description of the access key to update.
 
         Raise:
         AuthException: raised if update operation fails

--- a/descope/management/access_key.py
+++ b/descope/management/access_key.py
@@ -131,7 +131,7 @@ class AccessKey(AuthBase):
         Args:
         id (str): The id of the access key to update.
         name (str): The updated access key name.
-        description (str): The description of the access key to update.
+        description (str): The description of the access key to update. (If not provided, will not be override)
 
         Raise:
         AuthException: raised if update operation fails

--- a/descope/management/access_key.py
+++ b/descope/management/access_key.py
@@ -123,7 +123,7 @@ class AccessKey(AuthBase):
         self,
         id: str,
         name: str,
-        description: str,
+        description: Optional[str] = None,
     ):
         """
         Update an existing access key with the given various fields. IMPORTANT: All parameters are used as overrides
@@ -132,7 +132,7 @@ class AccessKey(AuthBase):
         Args:
         id (str): The id of the access key to update.
         name (str): The updated access key name.
-        description(str): an optional text the access key can hold.
+        description(str): The description of the access key to update.
 
         Raise:
         AuthException: raised if update operation fails

--- a/descope/management/access_key.py
+++ b/descope/management/access_key.py
@@ -17,6 +17,7 @@ class AccessKey(AuthBase):
         key_tenants: Optional[List[AssociatedTenant]] = None,
         user_id: Optional[str] = None,
         custom_claims: Optional[dict] = None,
+        description: Optional[str] = None,
         permitted_ips: Optional[List[str]] = None,
     ) -> dict:
         """
@@ -32,6 +33,7 @@ class AccessKey(AuthBase):
         user_id (str): Bind access key to this user id
             If user_id is supplied, then authorizations will be ignored, and the access key will be bound to the user's authorization.
         custom_claims (dict): Optional, map of claims and their values that will be present in the JWT.
+        description: an optional text the access key can hold.
         permitted_ips: (List[str]): An optional list of IP addresses or CIDR ranges that are allowed to use the access key.
 
         Return value (dict):
@@ -58,6 +60,7 @@ class AccessKey(AuthBase):
                 key_tenants,
                 user_id,
                 custom_claims,
+                description,
                 permitted_ips,
             ),
             pswd=self._auth.management_key,
@@ -120,6 +123,7 @@ class AccessKey(AuthBase):
         self,
         id: str,
         name: str,
+        description: str,
     ):
         """
         Update an existing access key with the given various fields. IMPORTANT: All parameters are used as overrides
@@ -128,13 +132,14 @@ class AccessKey(AuthBase):
         Args:
         id (str): The id of the access key to update.
         name (str): The updated access key name.
+        description(str): an optional text the access key can hold.
 
         Raise:
         AuthException: raised if update operation fails
         """
         self._auth.do_post(
             MgmtV1.access_key_update_path,
-            {"id": id, "name": name},
+            {"id": id, "name": name, "description": description},
             pswd=self._auth.management_key,
         )
 
@@ -205,6 +210,7 @@ class AccessKey(AuthBase):
         key_tenants: List[AssociatedTenant],
         user_id: Optional[str] = None,
         custom_claims: Optional[dict] = None,
+        description: Optional[str] = None,
         permitted_ips: Optional[List[str]] = None,
     ) -> dict:
         return {
@@ -214,5 +220,6 @@ class AccessKey(AuthBase):
             "keyTenants": associated_tenants_to_dict(key_tenants),
             "userId": user_id,
             "customClaims": custom_claims,
+            "description": description,
             "permittedIps": permitted_ips,
         }

--- a/descope/management/access_key.py
+++ b/descope/management/access_key.py
@@ -17,7 +17,7 @@ class AccessKey(AuthBase):
         key_tenants: Optional[List[AssociatedTenant]] = None,
         user_id: Optional[str] = None,
         custom_claims: Optional[dict] = None,
-        description: Optional[str] = None,
+        description: Optional[str] = "",
         permitted_ips: Optional[List[str]] = None,
     ) -> dict:
         """
@@ -123,7 +123,7 @@ class AccessKey(AuthBase):
         self,
         id: str,
         name: str,
-        description: Optional[str] = None,
+        description: Optional[str] = "",
     ):
         """
         Update an existing access key with the given various fields. IMPORTANT: All parameters are used as overrides

--- a/descope/management/access_key.py
+++ b/descope/management/access_key.py
@@ -17,7 +17,7 @@ class AccessKey(AuthBase):
         key_tenants: Optional[List[AssociatedTenant]] = None,
         user_id: Optional[str] = None,
         custom_claims: Optional[dict] = None,
-        description: Optional[str] = "",
+        description: str = "",
         permitted_ips: Optional[List[str]] = None,
     ) -> dict:
         """
@@ -123,7 +123,7 @@ class AccessKey(AuthBase):
         self,
         id: str,
         name: str,
-        description: Optional[str] = "",
+        description: str = "",
     ):
         """
         Update an existing access key with the given various fields. IMPORTANT: All parameters are used as overrides

--- a/tests/management/test_access_key.py
+++ b/tests/management/test_access_key.py
@@ -187,18 +187,14 @@ class TestAccessKey(common.DescopeTest):
                 client.mgmt.access_key.update,
                 "key-id",
                 "new-name",
-                "new description",
+                "",
             )
 
         # Test success flow
         with patch("requests.post") as mock_post:
             mock_post.return_value.ok = True
             self.assertIsNone(
-                client.mgmt.access_key.update(
-                    "key-id",
-                    name="new-name",
-                    description="new description"
-                )
+                client.mgmt.access_key.update("key-id", name="new-name", description="")
             )
             mock_post.assert_called_with(
                 f"{common.DEFAULT_BASE_URL}{MgmtV1.access_key_update_path}",
@@ -210,7 +206,7 @@ class TestAccessKey(common.DescopeTest):
                 json={
                     "id": "key-id",
                     "name": "new-name",
-                    "description": "new description",
+                    "description": "",
                 },
                 allow_redirects=False,
                 verify=True,

--- a/tests/management/test_access_key.py
+++ b/tests/management/test_access_key.py
@@ -187,14 +187,15 @@ class TestAccessKey(common.DescopeTest):
                 client.mgmt.access_key.update,
                 "key-id",
                 "new-name",
-                "",
             )
 
         # Test success flow
         with patch("requests.post") as mock_post:
             mock_post.return_value.ok = True
             self.assertIsNone(
-                client.mgmt.access_key.update("key-id", name="new-name", description="")
+                client.mgmt.access_key.update(
+                    "key-id", name="new-name", description=None
+                )
             )
             mock_post.assert_called_with(
                 f"{common.DEFAULT_BASE_URL}{MgmtV1.access_key_update_path}",
@@ -206,7 +207,7 @@ class TestAccessKey(common.DescopeTest):
                 json={
                     "id": "key-id",
                     "name": "new-name",
-                    "description": "",
+                    "description": None,
                 },
                 allow_redirects=False,
                 verify=True,

--- a/tests/management/test_access_key.py
+++ b/tests/management/test_access_key.py
@@ -58,6 +58,7 @@ class TestAccessKey(common.DescopeTest):
                 ],
                 user_id="userid",
                 custom_claims={"k1": "v1"},
+                description="this is my access key",
                 permitted_ips=["10.0.0.1", "192.168.1.0/24"],
             )
             access_key = resp["key"]
@@ -79,6 +80,7 @@ class TestAccessKey(common.DescopeTest):
                     ],
                     "userId": "userid",
                     "customClaims": {"k1": "v1"},
+                    "description": "this is my access key",
                     "permittedIps": ["10.0.0.1", "192.168.1.0/24"],
                 },
                 allow_redirects=False,
@@ -185,6 +187,7 @@ class TestAccessKey(common.DescopeTest):
                 client.mgmt.access_key.update,
                 "key-id",
                 "new-name",
+                "new description",
             )
 
         # Test success flow
@@ -194,6 +197,7 @@ class TestAccessKey(common.DescopeTest):
                 client.mgmt.access_key.update(
                     "key-id",
                     name="new-name",
+                    description="new description"
                 )
             )
             mock_post.assert_called_with(
@@ -206,6 +210,7 @@ class TestAccessKey(common.DescopeTest):
                 json={
                     "id": "key-id",
                     "name": "new-name",
+                    "description": "new description",
                 },
                 allow_redirects=False,
                 verify=True,


### PR DESCRIPTION
## Related Issues

Related https://github.com/descope/etc/issues/6938

## Description

Adding the description field to accessKey (create and update).
## Must

- [X] Tests
- [X] Documentation (if applicable)