### PR TITLE
Management User Add Tenant Roles API upgrade

### DIFF
--- a/descope/management/common.py
+++ b/descope/management/common.py
@@ -40,7 +40,7 @@ class MgmtV1:
     user_update_picture_path = "/v1/mgmt/user/update/picture"
     user_update_custom_attribute_path = "/v1/mgmt/user/update/customAttribute"
     user_set_role_path = "/v1/mgmt/user/update/role/set"
-    user_add_role_path = "/v1/mgmt/user/update/role/add"
+    user_add_role_path = "/v2/mgmt/user/update/role/add"
     user_remove_role_path = "/v1/mgmt/user/update/role/remove"
     user_add_sso_apps = "/v1/mgmt/user/update/ssoapp/add"
     user_set_sso_apps = "/v1/mgmt/user/update/ssoapp/set"


### PR DESCRIPTION
## Description

Updates the version for the Management User Add Tenant Roles API. 
With this new version, roles will be added to the tenant even if the user does not have access to the tenant. Access to the tenant will be added.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
