### PR TITLE
Allow updating jwt expiry via SDK

### DIFF
--- a/descope/management/jwt.py
+++ b/descope/management/jwt.py
@@ -6,13 +6,16 @@ from descope.management.common import MgmtV1
 
 
 class JWT(AuthBase):
-    def update_jwt(self, jwt: str, custom_claims: dict) -> str:
+    def update_jwt(
+        self, jwt: str, custom_claims: dict, refresh_duration: Optional[int]
+    ) -> str:
         """
         Given a valid JWT, update it with custom claims, and update its authz claims as well
 
         Args:
         token (str): valid jwt.
         custom_claims (dict): Custom claims to add to JWT, system claims will be filtered out
+        refresh_duration (int): duration in seconds for which the new JWT will be valid
 
         Return value (str): the newly updated JWT
 
@@ -23,7 +26,11 @@ class JWT(AuthBase):
             raise AuthException(400, ERROR_TYPE_INVALID_ARGUMENT, "jwt cannot be empty")
         response = self._auth.do_post(
             MgmtV1.update_jwt_path,
-            {"jwt": jwt, "customClaims": custom_claims},
+            {
+                "jwt": jwt,
+                "customClaims": custom_claims,
+                "refreshDuration": refresh_duration,
+            },
             pswd=self._auth.management_key,
         )
         return response.json().get("jwt", "")

--- a/tests/management/test_jwt.py
+++ b/tests/management/test_jwt.py
@@ -36,11 +36,11 @@ class TestUser(common.DescopeTest):
         with patch("requests.post") as mock_post:
             mock_post.return_value.ok = False
             self.assertRaises(
-                AuthException, client.mgmt.jwt.update_jwt, "jwt", {"k1": "v1"}
+                AuthException, client.mgmt.jwt.update_jwt, "jwt", {"k1": "v1"}, 0
             )
 
             self.assertRaises(
-                AuthException, client.mgmt.jwt.update_jwt, "", {"k1": "v1"}
+                AuthException, client.mgmt.jwt.update_jwt, "", {"k1": "v1"}, 0
             )
 
         # Test success flow
@@ -49,7 +49,7 @@ class TestUser(common.DescopeTest):
             network_resp.ok = True
             network_resp.json.return_value = json.loads("""{"jwt": "response"}""")
             mock_post.return_value = network_resp
-            resp = client.mgmt.jwt.update_jwt("test", {"k1": "v1"})
+            resp = client.mgmt.jwt.update_jwt("test", {"k1": "v1"}, 40)
             self.assertEqual(resp, "response")
             expected_uri = f"{common.DEFAULT_BASE_URL}{MgmtV1.update_jwt_path}"
             mock_post.assert_called_with(
@@ -58,7 +58,11 @@ class TestUser(common.DescopeTest):
                     **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
                 },
-                json={"jwt": "test", "customClaims": {"k1": "v1"}},
+                json={
+                    "jwt": "test",
+                    "customClaims": {"k1": "v1"},
+                    "refreshDuration": 40,
+                },
                 allow_redirects=False,
                 verify=True,
                 params=None,


### PR DESCRIPTION
Supported as part of jwt update flow
+test
fixes https://github.com/descope/etc/issues/8900
