### PR TITLE
Multi SSO - allow to pass sso ID for sso start method

### DIFF
--- a/descope/authmethod/sso.py
+++ b/descope/authmethod/sso.py
@@ -12,6 +12,8 @@ class SSO(AuthBase):
         return_url: Optional[str] = None,
         login_options: Optional[LoginOptions] = None,
         refresh_token: Optional[str] = None,
+        prompt: Optional[str] = None,
+        sso_id: Optional[str] = None,
     ) -> dict:
         """
         Start tenant sso session (saml/oidc based on tenant settings)
@@ -28,7 +30,12 @@ class SSO(AuthBase):
         validate_refresh_token_provided(login_options, refresh_token)
 
         uri = EndpointsV1.auth_sso_start_path
-        params = SSO._compose_start_params(tenant, return_url if return_url else "")
+        params = SSO._compose_start_params(
+            tenant,
+            return_url if return_url else "",
+            prompt if prompt else "",
+            sso_id if sso_id else "",
+        )
         response = self._auth.do_post(
             uri, login_options.__dict__ if login_options else {}, params, refresh_token
         )
@@ -40,8 +47,14 @@ class SSO(AuthBase):
         return self._auth.exchange_token(uri, code)
 
     @staticmethod
-    def _compose_start_params(tenant: str, return_url: str) -> dict:
+    def _compose_start_params(
+        tenant: str, return_url: str, prompt: str, sso_id: str
+    ) -> dict:
         res = {"tenant": tenant}
         if return_url is not None and return_url != "":
             res["redirectURL"] = return_url
+        if prompt is not None and prompt != "":
+            res["prompt"] = prompt
+        if sso_id is not None and sso_id != "":
+            res["ssoId"] = sso_id
         return res

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -27,8 +27,18 @@ class TestSSO(common.DescopeTest):
 
     def test_compose_start_params(self):
         self.assertEqual(
-            SSO._compose_start_params("tenant1", "http://dummy.com"),
+            SSO._compose_start_params("tenant1", "http://dummy.com", "", ""),
             {"tenant": "tenant1", "redirectURL": "http://dummy.com"},
+        )
+
+        self.assertEqual(
+            SSO._compose_start_params("tenant1", "http://dummy.com", "bla", "blue"),
+            {
+                "tenant": "tenant1",
+                "redirectURL": "http://dummy.com",
+                "prompt": "bla",
+                "ssoId": "blue",
+            },
         )
 
     def test_sso_start(self):
@@ -49,7 +59,7 @@ class TestSSO(common.DescopeTest):
 
         with patch("requests.post") as mock_post:
             mock_post.return_value.ok = True
-            sso.start("tenant1", "http://dummy.com")
+            sso.start("tenant1", "http://dummy.com", sso_id="some-sso-id")
             expected_uri = f"{common.DEFAULT_BASE_URL}{EndpointsV1.auth_sso_start_path}"
             mock_post.assert_called_with(
                 expected_uri,
@@ -57,7 +67,11 @@ class TestSSO(common.DescopeTest):
                     **common.default_headers,
                     "Authorization": f"Bearer {self.dummy_project_id}",
                 },
-                params={"tenant": "tenant1", "redirectURL": "http://dummy.com"},
+                params={
+                    "tenant": "tenant1",
+                    "redirectURL": "http://dummy.com",
+                    "ssoId": "some-sso-id",
+                },
                 json={},
                 allow_redirects=False,
                 verify=True,


### PR DESCRIPTION
## Description
Multi SSO - allow to pass SSO ID for sso start method, only relevant when using Multi SSO.

Related to https://github.com/descope/etc/issues/2119

## Must
- [x] Tests
- [ ] Documentation (if applicable)
