### PR TITLE
feat: Added modified and created time parameters

### DIFF
--- a/descope/management/user.py
+++ b/descope/management/user.py
@@ -595,6 +595,10 @@ class User(AuthBase):
         sort: Optional[List[Sort]] = None,
         text: Optional[str] = None,
         login_ids: Optional[List[str]] = None,
+        from_created_time: Optional[int] = None,
+        to_created_time: Optional[int] = None,
+        from_modified_time: Optional[int] = None,
+        to_modified_time: Optional[int] = None,
     ) -> dict:
         """
         Search all users.
@@ -614,6 +618,10 @@ class User(AuthBase):
         text (str): Optional string, allows free text search among all user's attributes.
         login_ids (List[str]): Optional list of login ids
         sort (List[Sort]): Optional List[dict], allows to sort by fields.
+        from_created_time (int): Optional int, only include users who were created on or after this time (in Unix epoch seconds)
+        to_created_time (int): Optional int, only include users who were created on or before this time (in Unix epoch seconds)
+        from_modified_time (int): Optional int, only include users whose last modification/update occurred on or after this time (in Unix epoch seconds)
+        to_modified_time (int): Optional int, only include users whose last modification/update occurred on or before this time (in Unix epoch seconds)
 
         Return value (dict):
         Return dict in the format
@@ -667,6 +675,15 @@ class User(AuthBase):
         if sort is not None:
             body["sort"] = sort_to_dict(sort)
 
+        if from_created_time is not None:
+            body["fromCreatedTime"] = from_created_time
+        if to_created_time is not None:
+            body["toCreatedTime"] = to_created_time
+        if from_modified_time is not None:
+            body["fromModifiedTime"] = from_modified_time
+        if to_modified_time is not None:
+            body["toModifiedTime"] = to_modified_time
+
         response = self._auth.do_post(
             MgmtV1.users_search_path,
             body=body,
@@ -688,6 +705,10 @@ class User(AuthBase):
         sort: Optional[List[Sort]] = None,
         text: Optional[str] = None,
         login_ids: Optional[List[str]] = None,
+        from_created_time: Optional[int] = None,
+        to_created_time: Optional[int] = None,
+        from_modified_time: Optional[int] = None,
+        to_modified_time: Optional[int] = None,
     ) -> dict:
         """
         Search all test users.
@@ -705,6 +726,10 @@ class User(AuthBase):
         text (str): Optional string, allows free text search among all user's attributes.
         login_ids (List[str]): Optional list of login ids
         sort (List[Sort]): Optional List[dict], allows to sort by fields.
+        from_created_time (int): Optional int, only include users who were created on or after this time (in Unix epoch seconds)
+        to_created_time (int): Optional int, only include users who were created on or before this time (in Unix epoch seconds)
+        from_modified_time (int): Optional int, only include users whose last modification/update occurred on or after this time (in Unix epoch seconds)
+        to_modified_time (int): Optional int, only include users whose last modification/update occurred on or before this time (in Unix epoch seconds)
 
         Return value (dict):
         Return dict in the format
@@ -757,6 +782,15 @@ class User(AuthBase):
 
         if sort is not None:
             body["sort"] = sort_to_dict(sort)
+
+        if from_created_time is not None:
+            body["fromCreatedTime"] = from_created_time
+        if to_created_time is not None:
+            body["toCreatedTime"] = to_created_time
+        if from_modified_time is not None:
+            body["fromModifiedTime"] = from_modified_time
+        if to_modified_time is not None:
+            body["toModifiedTime"] = to_modified_time
 
         response = self._auth.do_post(
             MgmtV1.test_users_search_path,

--- a/tests/management/test_user.py
+++ b/tests/management/test_user.py
@@ -965,6 +965,48 @@ class TestUser(common.DescopeTest):
                 verify=True,
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
+        
+        # Test success flow with time parameters
+        with patch("requests.post") as mock_post:
+            network_resp = mock.Mock()
+            network_resp.ok = True
+            network_resp.json.return_value = json.loads("""{"users": [{"id": "u1"}]}""")
+            mock_post.return_value = network_resp
+            resp = self.client.mgmt.user.search_all(
+                from_created_time=100,
+                to_created_time=200,
+                from_modified_time=300,
+                to_modified_time=400,
+                limit=10,
+                page=0,
+            )
+            users = resp["users"]
+            self.assertEqual(len(users), 1)
+            self.assertEqual(users[0]["id"], "u1")
+            # Verify the request body includes our time parameters
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.users_search_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                },
+                params=None,
+                json={
+                    "tenantIds": [],
+                    "roleNames": [],
+                    "limit": 10,
+                    "page": 0,
+                    "testUsersOnly": False,
+                    "withTestUser": False,
+                    "fromCreatedTime": 100,
+                    "toCreatedTime": 200,
+                    "fromModifiedTime": 300,
+                    "toModifiedTime": 400,
+                },
+                allow_redirects=False,
+                verify=True,
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
 
     def test_search_all_test_users(self):
         # Test failed flows
@@ -1121,6 +1163,48 @@ class TestUser(common.DescopeTest):
                     "statuses": ["invited"],
                     "emails": ["a@b.com"],
                     "phones": ["+111111"],
+                },
+                allow_redirects=False,
+                verify=True,
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+
+        # Test success flow with time parameters
+        with patch("requests.post") as mock_post:
+            network_resp = mock.Mock()
+            network_resp.ok = True
+            network_resp.json.return_value = json.loads("""{"users": [{"id": "u1"}]}""")
+            mock_post.return_value = network_resp
+            resp = self.client.mgmt.user.search_all_test_users(
+                from_created_time=100,
+                to_created_time=200,
+                from_modified_time=300,
+                to_modified_time=400,
+                limit=10,
+                page=0,
+            )
+            users = resp["users"]
+            self.assertEqual(len(users), 1)
+            self.assertEqual(users[0]["id"], "u1")
+            # Verify the request body includes our time parameters
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.users_search_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                },
+                params=None,
+                json={
+                    "tenantIds": [],
+                    "roleNames": [],
+                    "limit": 10,
+                    "page": 0,
+                    "testUsersOnly": False,
+                    "withTestUser": False,
+                    "fromCreatedTime": 100,
+                    "toCreatedTime": 200,
+                    "fromModifiedTime": 300,
+                    "toModifiedTime": 400,
                 },
                 allow_redirects=False,
                 verify=True,


### PR DESCRIPTION
## Related Issues

Fixes <link_to_github_issue>

## Related PRs

| branch       | PR         |
| ------------ | ---------- |
| service a PR | Link to PR |
| service b PR | Link to PR |

## Description

Added the following options to the Python SDK:

```
from_created_time (int): Optional int, only include users who were created on or after this time (in Unix epoch seconds)
        to_created_time (int): Optional int, only include users who were created on or before this time (in Unix epoch seconds)
        from_modified_time (int): Optional int, only include users whose last modification/update occurred on or after this time (in Unix epoch seconds)
        to_modified_time (int): Optional int, only include users whose last modification/update occurred on or before this time (in Unix epoch seconds)
```

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
