### PR TITLE
Update jwt refresh duration default param fix

### DIFF
--- a/descope/management/jwt.py
+++ b/descope/management/jwt.py
@@ -13,7 +13,7 @@ from descope.management.common import (
 
 class JWT(AuthBase):
     def update_jwt(
-        self, jwt: str, custom_claims: dict, refresh_duration: Optional[int]
+        self, jwt: str, custom_claims: dict, refresh_duration: Optional[int] = 0
     ) -> str:
         """
         Given a valid JWT, update it with custom claims, and update its authz claims as well

--- a/descope/management/jwt.py
+++ b/descope/management/jwt.py
@@ -13,7 +13,7 @@ from descope.management.common import (
 
 class JWT(AuthBase):
     def update_jwt(
-        self, jwt: str, custom_claims: dict, refresh_duration: Optional[int] = 0
+        self, jwt: str, custom_claims: dict, refresh_duration: int = 0
     ) -> str:
         """
         Given a valid JWT, update it with custom claims, and update its authz claims as well

--- a/tests/management/test_jwt.py
+++ b/tests/management/test_jwt.py
@@ -69,6 +69,31 @@ class TestUser(common.DescopeTest):
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
 
+        with patch("requests.post") as mock_post:
+            network_resp = mock.Mock()
+            network_resp.ok = True
+            network_resp.json.return_value = json.loads("""{"jwt": "response"}""")
+            mock_post.return_value = network_resp
+            resp = client.mgmt.jwt.update_jwt("test", {"k1": "v1"})
+            self.assertEqual(resp, "response")
+            expected_uri = f"{common.DEFAULT_BASE_URL}{MgmtV1.update_jwt_path}"
+            mock_post.assert_called_with(
+                expected_uri,
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                },
+                json={
+                    "jwt": "test",
+                    "customClaims": {"k1": "v1"},
+                    "refreshDuration": 0,
+                },
+                allow_redirects=False,
+                verify=True,
+                params=None,
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+
     def test_impersonate(self):
         client = DescopeClient(
             self.dummy_project_id,

--- a/tests/management/test_jwt.py
+++ b/tests/management/test_jwt.py
@@ -69,12 +69,6 @@ class TestUser(common.DescopeTest):
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
 
-        # Test success flow without refresh duration
-        with patch("requests.post") as mock_post:
-            network_resp = mock.Mock()
-            network_resp.ok = True
-            network_resp.json.return_value = json.loads("""{"jwt": "response"}""")
-            mock_post.return_value = network_resp
             resp = client.mgmt.jwt.update_jwt("test", {"k1": "v1"})
             self.assertEqual(resp, "response")
             expected_uri = f"{common.DEFAULT_BASE_URL}{MgmtV1.update_jwt_path}"

--- a/tests/management/test_jwt.py
+++ b/tests/management/test_jwt.py
@@ -69,6 +69,7 @@ class TestUser(common.DescopeTest):
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
 
+        # Test success flow without refresh duration
         with patch("requests.post") as mock_post:
             network_resp = mock.Mock()
             network_resp.ok = True


### PR DESCRIPTION

## Related Issues
related <> 

## Related PRs
https://github.com/descope/python-sdk/pull/478

## Description
fix update jwt optional param default value
add test

## Must

- [x] Tests
- [ ] Documentation (if applicable)
