### PR TITLE
Add support for auth management key

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,23 @@ pip install descope[Flask]
 A Descope `Project ID` is required to initialize the SDK. Find it on the
 [project page in the Descope Console](https://app.descope.com/settings/project).
 
+**Note:** Authentication APIs public access can be disabled via the Descope console.
+If disabled, it's still possible to use the authentication API by providing a management key with
+the appropriate access (`Authentication` / `Full Access`).
+If not provided directly, this value is retrieved from the `DESCOPE_AUTH_MANAGEMENT_KEY` environment variable instead.
+If neither values are set then any disabled authentication methods API calls will fail.
+
 ```python
 from descope import DescopeClient
 
-# Initialized after setting the DESCOPE_PROJECT_ID env var
+# Initialized after setting the DESCOPE_PROJECT_ID and DESCOPE_AUTH_MANAGEMENT_KEY env vars
 descope_client = DescopeClient()
 
 # ** Or directly **
-descope_client = DescopeClient(project_id="<Project ID>")
+descope_client = DescopeClient(
+    project_id="<Project ID>"
+    auth_management_key="<Auth Managemet Key>
+)
 ```
 
 ## Authentication Functions
@@ -1178,7 +1187,7 @@ type doc
   permission can_create: owner | parent.owner
   permission can_edit: editor | can_create
   permission can_view: viewer | can_edit
-  ```
+```
 
 Descope SDK allows you to fully manage the schema and relations as well as perform simple (and not so simple) checks regarding the existence of relations.
 

--- a/descope/auth.py
+++ b/descope/auth.py
@@ -73,6 +73,7 @@ class Auth:
         management_key: str | None = None,
         timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
         jwt_validation_leeway: int = 5,
+        auth_management_key: str | None = None,
     ):
         self.lock_public_keys = Lock()
         # validate project id
@@ -95,6 +96,9 @@ class Auth:
             self.base_url = self.base_url_for_project_id(self.project_id)
         self.timeout_seconds = timeout_seconds
         self.management_key = management_key or os.getenv("DESCOPE_MANAGEMENT_KEY")
+        self.auth_management_key = auth_management_key or os.getenv(
+            "DESCOPE_AUTH_MANAGEMENT_KEY"
+        )
 
         public_key = public_key or os.getenv("DESCOPE_PUBLIC_KEY")
         with self.lock_public_keys:
@@ -564,6 +568,8 @@ class Auth:
         bearer = self.project_id
         if pswd:
             bearer = f"{self.project_id}:{pswd}"
+        if self.auth_management_key:
+            bearer = f"{bearer}:{self.auth_management_key}"
         headers["Authorization"] = f"Bearer {bearer}"
         return headers
 

--- a/descope/descope_client.py
+++ b/descope/descope_client.py
@@ -30,6 +30,7 @@ class DescopeClient:
         management_key: str | None = None,
         timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
         jwt_validation_leeway: int = 5,
+        auth_management_key: str | None = None,
     ):
         auth = Auth(
             project_id,
@@ -38,6 +39,7 @@ class DescopeClient:
             management_key,
             timeout_seconds,
             jwt_validation_leeway,
+            auth_management_key,
         )
         self._auth = auth
         self._mgmt = MGMT(auth)


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/8683

## Description

Add support for auth management key - allowing access to authentication methods that are disabled from public access via management key.

## Must

- [x] Tests
- [x] Documentation (if applicable)
