### PR TITLE
Introduce HTTPClient to encapsulate the different mgmt keys needs

### DIFF
--- a/descope/_auth_base.py
+++ b/descope/_auth_base.py
@@ -2,8 +2,10 @@
 from descope.auth import Auth
 
 
+# XXX in the future we can remove this class entirely and have auth methods be base HTTPBase instead
 class AuthBase:
     """Base class for classes having auth"""
 
     def __init__(self, auth: Auth):
         self._auth = auth
+        self._http = auth.http_client

--- a/descope/_http_base.py
+++ b/descope/_http_base.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from descope.http_client import HTTPClient
+
+
+class HTTPBase:
+    """Base class for classes that only need HTTP access."""
+
+    def __init__(self, http_client: HTTPClient):
+        self._http = http_client

--- a/descope/auth.py
+++ b/descope/auth.py
@@ -3,20 +3,12 @@ from __future__ import annotations
 import copy
 import json
 import os
-import platform
 import re
 from http import HTTPStatus
 from threading import Lock
 from typing import Iterable
 
 import jwt
-
-try:
-    from importlib.metadata import version
-except ImportError:
-    from pkg_resources import get_distribution
-
-import requests
 from email_validator import EmailNotValidError, validate_email
 from jwt import ExpiredSignatureError, ImmatureSignatureError
 
@@ -24,7 +16,6 @@ from descope.common import (
     COOKIE_DATA_NAME,
     DEFAULT_BASE_URL,
     DEFAULT_DOMAIN,
-    DEFAULT_TIMEOUT_SECONDS,
     DEFAULT_URL_PREFIX,
     PHONE_REGEX,
     REFRESH_SESSION_COOKIE_NAME,
@@ -45,21 +36,10 @@ from descope.exceptions import (
     AuthException,
     RateLimitException,
 )
-
-
-def sdk_version():
-    try:
-        return version("descope")
-    except NameError:
-        return get_distribution("descope").version
-
-
-_default_headers = {
-    "Content-Type": "application/json",
-    "x-descope-sdk-name": "python",
-    "x-descope-sdk-python-version": platform.python_version(),
-    "x-descope-sdk-version": sdk_version(),
-}
+from descope.http_client import HTTPClient
+from descope.jwt_common import adjust_properties as jwt_adjust_properties
+from descope.jwt_common import generate_auth_info as jwt_generate_auth_info
+from descope.jwt_common import generate_jwt_response as jwt_generate_jwt_response
 
 
 class Auth:
@@ -69,11 +49,9 @@ class Auth:
         self,
         project_id: str | None = None,
         public_key: dict | str | None = None,
-        skip_verify: bool = False,
-        management_key: str | None = None,
-        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
         jwt_validation_leeway: int = 5,
-        auth_management_key: str | None = None,
+        *,
+        http_client: HTTPClient,
     ):
         self.lock_public_keys = Lock()
         # validate project id
@@ -89,16 +67,9 @@ class Auth:
             )
         self.project_id = project_id
         self.jwt_validation_leeway = jwt_validation_leeway
-        self.secure = not skip_verify
 
-        self.base_url = os.getenv("DESCOPE_BASE_URI")
-        if not self.base_url:
-            self.base_url = self.base_url_for_project_id(self.project_id)
-        self.timeout_seconds = timeout_seconds
-        self.management_key = management_key or os.getenv("DESCOPE_MANAGEMENT_KEY")
-        self.auth_management_key = auth_management_key or os.getenv(
-            "DESCOPE_AUTH_MANAGEMENT_KEY"
-        )
+        # Internal HTTP client for all network traffic (must be injected)
+        self._http = http_client
 
         public_key = public_key or os.getenv("DESCOPE_PUBLIC_KEY")
         with self.lock_public_keys:
@@ -138,75 +109,9 @@ class Auth:
         except (ValueError, TypeError):
             return 0
 
-    def do_get(
-        self,
-        uri: str,
-        params=None,
-        allow_redirects=None,
-        pswd: str | None = None,
-    ) -> requests.Response:
-        response = requests.get(
-            f"{self.base_url}{uri}",
-            headers=self._get_default_headers(pswd),
-            params=params,
-            allow_redirects=allow_redirects,
-            verify=self.secure,
-            timeout=self.timeout_seconds,
-        )
-        self._raise_from_response(response)
-        return response
-
-    def do_post(
-        self,
-        uri: str,
-        body: dict | list[dict] | list[str] | None,
-        params=None,
-        pswd: str | None = None,
-    ) -> requests.Response:
-        response = requests.post(
-            f"{self.base_url}{uri}",
-            headers=self._get_default_headers(pswd),
-            json=body,
-            allow_redirects=False,
-            verify=self.secure,
-            params=params,
-            timeout=self.timeout_seconds,
-        )
-        self._raise_from_response(response)
-        return response
-
-    def do_patch(
-        self,
-        uri: str,
-        body: dict | list[dict] | list[str] | None,
-        params=None,
-        pswd: str | None = None,
-    ) -> requests.Response:
-        response = requests.patch(
-            f"{self.base_url}{uri}",
-            headers=self._get_default_headers(pswd),
-            json=body,
-            allow_redirects=False,
-            verify=self.secure,
-            params=params,
-            timeout=self.timeout_seconds,
-        )
-        self._raise_from_response(response)
-        return response
-
-    def do_delete(
-        self, uri: str, params=None, pswd: str | None = None
-    ) -> requests.Response:
-        response = requests.delete(
-            f"{self.base_url}{uri}",
-            params=params,
-            headers=self._get_default_headers(pswd),
-            allow_redirects=False,
-            verify=self.secure,
-            timeout=self.timeout_seconds,
-        )
-        self._raise_from_response(response)
-        return response
+    @property
+    def http_client(self) -> HTTPClient:
+        return self._http
 
     def exchange_token(
         self, uri, code: str, audience: str | None | Iterable[str] = None
@@ -219,7 +124,7 @@ class Auth:
             )
 
         body = Auth._compose_exchange_body(code)
-        response = self.do_post(uri=uri, body=body, params=None)
+        response = self._http.post(uri, body=body)
         resp = response.json()
         jwt_response = self.generate_jwt_response(
             resp, response.cookies.get(REFRESH_SESSION_COOKIE_NAME), audience
@@ -304,23 +209,6 @@ class Auth:
         return login_id
 
     @staticmethod
-    def get_method_string(method: DeliveryMethod) -> str:
-        name = {
-            DeliveryMethod.EMAIL: "email",
-            DeliveryMethod.SMS: "sms",
-            DeliveryMethod.VOICE: "voice",
-            DeliveryMethod.WHATSAPP: "whatsapp",
-            DeliveryMethod.EMBEDDED: "Embedded",
-        }.get(method)
-
-        if not name:
-            raise AuthException(
-                400, ERROR_TYPE_INVALID_ARGUMENT, f"Unknown delivery method: {method}"
-            )
-
-        return name
-
-    @staticmethod
     def validate_email(email: str):
         if email == "":
             raise AuthException(
@@ -369,10 +257,13 @@ class Auth:
         body = {
             "loginOptions": login_options.__dict__ if login_options else {},
         }
-        server_response = self.do_post(uri=uri, body=body, params=None, pswd=access_key)
-        json = server_response.json()
+        server_response = self._http.post(uri, body=body, pswd=access_key)
+        json_body = server_response.json()
         return self._generate_auth_info(
-            response_body=json, refresh_token=None, user_jwt=False, audience=audience
+            response_body=json_body,
+            refresh_token=None,
+            user_jwt=False,
+            audience=audience,
         )
 
     @staticmethod
@@ -439,13 +330,9 @@ class Auth:
 
     def _fetch_public_keys(self) -> None:
         # This function called under mutex protection so no need to acquire it once again
-        response = requests.get(
-            f"{self.base_url}{EndpointsV2.public_key_path}/{self.project_id}",
-            headers=self._get_default_headers(),
-            verify=self.secure,
-            timeout=self.timeout_seconds,
+        response = self._http.get(
+            f"{EndpointsV2.public_key_path}/{self.project_id}",
         )
-        self._raise_from_response(response)
 
         jwks_data = response.text
         try:
@@ -467,55 +354,8 @@ class Auth:
                 pass
 
     def adjust_properties(self, jwt_response: dict, user_jwt: bool):
-        # Save permissions, roles and tenants info from Session token or from refresh token on the json top level
-        if SESSION_TOKEN_NAME in jwt_response:
-            jwt_response["permissions"] = jwt_response[SESSION_TOKEN_NAME].get(
-                "permissions", []
-            )
-            jwt_response["roles"] = jwt_response[SESSION_TOKEN_NAME].get("roles", [])
-            jwt_response["tenants"] = jwt_response[SESSION_TOKEN_NAME].get(
-                "tenants", {}
-            )
-        elif REFRESH_SESSION_TOKEN_NAME in jwt_response:
-            jwt_response["permissions"] = jwt_response[REFRESH_SESSION_TOKEN_NAME].get(
-                "permissions", []
-            )
-            jwt_response["roles"] = jwt_response[REFRESH_SESSION_TOKEN_NAME].get(
-                "roles", []
-            )
-            jwt_response["tenants"] = jwt_response[REFRESH_SESSION_TOKEN_NAME].get(
-                "tenants", {}
-            )
-        else:
-            jwt_response["permissions"] = jwt_response.get("permissions", [])
-            jwt_response["roles"] = jwt_response.get("roles", [])
-            jwt_response["tenants"] = jwt_response.get("tenants", {})
-
-        # Save the projectID also in the dict top level
-        issuer = (
-            jwt_response.get(SESSION_TOKEN_NAME, {}).get("iss", None)
-            or jwt_response.get(REFRESH_SESSION_TOKEN_NAME, {}).get("iss", None)
-            or jwt_response.get("iss", "")
-        )
-        jwt_response["projectId"] = issuer.rsplit("/")[
-            -1
-        ]  # support both url issuer and project ID issuer
-
-        sub = (
-            jwt_response.get(SESSION_TOKEN_NAME, {}).get("dsub", None)
-            or jwt_response.get(SESSION_TOKEN_NAME, {}).get("sub", None)
-            or jwt_response.get(REFRESH_SESSION_TOKEN_NAME, {}).get("dsub", None)
-            or jwt_response.get(REFRESH_SESSION_TOKEN_NAME, {}).get("sub", None)
-            or jwt_response.get("sub", "")
-        )
-        if user_jwt:
-            # Save the userID also in the dict top level
-            jwt_response["userId"] = sub
-        else:
-            # Save the AccessKeyID also in the dict top level
-            jwt_response["keyId"] = sub
-
-        return jwt_response
+        # Delegate to shared JWT utilities for normalization
+        return jwt_adjust_properties(jwt_response, user_jwt)
 
     def _generate_auth_info(
         self,
@@ -524,31 +364,14 @@ class Auth:
         user_jwt: bool,
         audience: str | None | Iterable[str] = None,
     ) -> dict:
-        jwt_response = {}
-        st_jwt = response_body.get("sessionJwt", "")
-        if st_jwt:
-            jwt_response[SESSION_TOKEN_NAME] = self._validate_token(st_jwt, audience)
-        rt_jwt = response_body.get("refreshJwt", "")
-        if rt_jwt:
-            jwt_response[REFRESH_SESSION_TOKEN_NAME] = self._validate_token(
-                rt_jwt, audience
-            )
-        elif refresh_token:
-            jwt_response[REFRESH_SESSION_TOKEN_NAME] = self._validate_token(
-                refresh_token, audience
-            )
-
-        jwt_response = self.adjust_properties(jwt_response, user_jwt)
-
-        if user_jwt:
-            jwt_response[COOKIE_DATA_NAME] = {
-                "exp": response_body.get("cookieExpiration", 0),
-                "maxAge": response_body.get("cookieMaxAge", 0),
-                "domain": response_body.get("cookieDomain", ""),
-                "path": response_body.get("cookiePath", "/"),
-            }
-
-        return jwt_response
+        # Use shared generator with class validator to preserve signature checks
+        return jwt_generate_auth_info(
+            response_body,
+            refresh_token,
+            user_jwt,
+            audience,
+            token_validator=self._validate_token,
+        )
 
     def generate_jwt_response(
         self,
@@ -556,24 +379,16 @@ class Auth:
         refresh_cookie: str | None,
         audience: str | None | Iterable[str] = None,
     ) -> dict:
-        jwt_response = self._generate_auth_info(
-            response_body, refresh_cookie, True, audience
+        # Delegate to shared implementation (keeps same output shape)
+        return jwt_generate_jwt_response(
+            response_body,
+            refresh_cookie,
+            audience,
+            token_validator=self._validate_token,
         )
 
-        jwt_response["user"] = response_body.get("user", {})
-        jwt_response["firstSeen"] = response_body.get("firstSeen", True)
-        return jwt_response
-
     def _get_default_headers(self, pswd: str | None = None):
-        headers = _default_headers.copy()
-        headers["x-descope-project-id"] = self.project_id
-        bearer = self.project_id
-        if pswd:
-            bearer = f"{self.project_id}:{pswd}"
-        if self.auth_management_key:
-            bearer = f"{bearer}:{self.auth_management_key}"
-        headers["Authorization"] = f"Bearer {bearer}"
-        return headers
+        return self._http.get_default_headers(pswd)
 
     # Validate a token and load the public key if needed
     def _validate_token(
@@ -676,7 +491,7 @@ class Auth:
         self._validate_token(refresh_token, audience)
 
         uri = EndpointsV1.refresh_token_path
-        response = self.do_post(uri=uri, body={}, params=None, pswd=refresh_token)
+        response = self._http.post(uri, body={}, pswd=refresh_token)
 
         resp = response.json()
         refresh_token = (
@@ -723,9 +538,7 @@ class Auth:
             )
 
         uri = EndpointsV1.select_tenant_path
-        response = self.do_post(
-            uri=uri, body={"tenant": tenant_id}, params=None, pswd=refresh_token
-        )
+        response = self._http.post(uri, body={"tenant": tenant_id}, pswd=refresh_token)
 
         resp = response.json()
         jwt_response = self.generate_jwt_response(

--- a/descope/authmethod/enchantedlink.py
+++ b/descope/authmethod/enchantedlink.py
@@ -34,9 +34,8 @@ class EnchantedLink(AuthBase):
         validate_refresh_token_provided(login_options, refresh_token)
 
         body = EnchantedLink._compose_signin_body(login_id, uri, login_options)
-        uri = EnchantedLink._compose_signin_url()
-
-        response = self._auth.do_post(uri, body, None, refresh_token)
+        url = EnchantedLink._compose_signin_url()
+        response = self._http.post(url, body=body, pswd=refresh_token)
         return EnchantedLink._get_pending_ref_from_response(response)
 
     def sign_up(
@@ -59,8 +58,8 @@ class EnchantedLink(AuthBase):
             )
 
         body = EnchantedLink._compose_signup_body(login_id, uri, user, signup_options)
-        uri = EnchantedLink._compose_signup_url()
-        response = self._auth.do_post(uri, body, None)
+        url = EnchantedLink._compose_signup_url()
+        response = self._http.post(url, body=body)
         return EnchantedLink._get_pending_ref_from_response(response)
 
     def sign_up_or_in(
@@ -79,15 +78,14 @@ class EnchantedLink(AuthBase):
             uri,
             login_options,
         )
-        uri = EnchantedLink._compose_sign_up_or_in_url()
-        response = self._auth.do_post(uri, body, None)
+        url = EnchantedLink._compose_sign_up_or_in_url()
+        response = self._http.post(url, body=body)
         return EnchantedLink._get_pending_ref_from_response(response)
 
     def get_session(self, pending_ref: str) -> dict:
         uri = EndpointsV1.get_session_enchantedlink_auth_path
         body = EnchantedLink._compose_get_session_body(pending_ref)
-        response = self._auth.do_post(uri, body, None)
-
+        response = self._http.post(uri, body=body)
         resp = response.json()
         jwt_response = self._auth.generate_jwt_response(
             resp, response.cookies.get(REFRESH_SESSION_COOKIE_NAME, None), None
@@ -97,7 +95,7 @@ class EnchantedLink(AuthBase):
     def verify(self, token: str):
         uri = EndpointsV1.verify_enchantedlink_auth_path
         body = EnchantedLink._compose_verify_body(token)
-        self._auth.do_post(uri, body, None)
+        self._http.post(uri, body=body)
 
     def update_user_email(
         self,
@@ -127,7 +125,7 @@ class EnchantedLink(AuthBase):
             provider_id,
         )
         uri = EndpointsV1.update_user_email_enchantedlink_path
-        response = self._auth.do_post(uri, body, None, refresh_token)
+        response = self._http.post(uri, body=body, pswd=refresh_token)
         return EnchantedLink._get_pending_ref_from_response(response)
 
     @staticmethod

--- a/descope/authmethod/magiclink.py
+++ b/descope/authmethod/magiclink.py
@@ -35,9 +35,8 @@ class MagicLink(AuthBase):
         validate_refresh_token_provided(login_options, refresh_token)
 
         body = MagicLink._compose_signin_body(login_id, uri, login_options)
-        uri = MagicLink._compose_signin_url(method)
-
-        response = self._auth.do_post(uri, body, None, refresh_token)
+        url = MagicLink._compose_signin_url(method)
+        response = self._http.post(url, body=body, pswd=refresh_token)
         return Auth.extract_masked_address(response.json(), method)
 
     def sign_up(
@@ -61,8 +60,8 @@ class MagicLink(AuthBase):
         body = MagicLink._compose_signup_body(
             method, login_id, uri, user, signup_options
         )
-        uri = MagicLink._compose_signup_url(method)
-        response = self._auth.do_post(uri, body, None)
+        url = MagicLink._compose_signup_url(method)
+        response = self._http.post(url, body=body)
         return Auth.extract_masked_address(response.json(), method)
 
     def sign_up_or_in(
@@ -84,14 +83,14 @@ class MagicLink(AuthBase):
             uri,
             login_options,
         )
-        uri = MagicLink._compose_sign_up_or_in_url(method)
-        response = self._auth.do_post(uri, body, None)
+        url = MagicLink._compose_sign_up_or_in_url(method)
+        response = self._http.post(url, body=body)
         return Auth.extract_masked_address(response.json(), method)
 
     def verify(self, token: str, audience: str | None | Iterable[str] = None) -> dict:
-        uri = EndpointsV1.verify_magiclink_auth_path
+        url = EndpointsV1.verify_magiclink_auth_path
         body = MagicLink._compose_verify_body(token)
-        response = self._auth.do_post(uri, body, None)
+        response = self._http.post(url, body=body)
         resp = response.json()
         jwt_response = self._auth.generate_jwt_response(
             resp, response.cookies.get(REFRESH_SESSION_COOKIE_NAME, None), audience
@@ -125,8 +124,8 @@ class MagicLink(AuthBase):
             template_id,
             provider_id,
         )
-        uri = EndpointsV1.update_user_email_magiclink_path
-        response = self._auth.do_post(uri, body, None, refresh_token)
+        url = EndpointsV1.update_user_email_magiclink_path
+        response = self._http.post(url, body=body, pswd=refresh_token)
         return Auth.extract_masked_address(response.json(), DeliveryMethod.EMAIL)
 
     def update_user_phone(
@@ -157,8 +156,8 @@ class MagicLink(AuthBase):
             template_id,
             provider_id,
         )
-        uri = EndpointsV1.update_user_phone_magiclink_path
-        response = self._auth.do_post(uri, body, None, refresh_token)
+        url = EndpointsV1.update_user_phone_magiclink_path
+        response = self._http.post(url, body=body, pswd=refresh_token)
         return Auth.extract_masked_address(response.json(), DeliveryMethod.SMS)
 
     @staticmethod

--- a/descope/authmethod/oauth.py
+++ b/descope/authmethod/oauth.py
@@ -25,8 +25,11 @@ class OAuth(AuthBase):
 
         uri = EndpointsV1.oauth_start_path
         params = OAuth._compose_start_params(provider, return_url)
-        response = self._auth.do_post(
-            uri, login_options.__dict__ if login_options else {}, params, refresh_token
+        response = self._http.post(
+            uri,
+            body=login_options.__dict__ if login_options else {},
+            params=params,
+            pswd=refresh_token,
         )
 
         return response.json()

--- a/descope/authmethod/otp.py
+++ b/descope/authmethod/otp.py
@@ -48,7 +48,7 @@ class OTP(AuthBase):
 
         uri = OTP._compose_signin_url(method)
         body = OTP._compose_signin_body(login_id, login_options)
-        response = self._auth.do_post(uri, body, None, refresh_token)
+        response = self._http.post(uri, body=body, pswd=refresh_token)
         return Auth.extract_masked_address(response.json(), method)
 
     def sign_up(
@@ -85,7 +85,7 @@ class OTP(AuthBase):
 
         uri = OTP._compose_signup_url(method)
         body = OTP._compose_signup_body(method, login_id, user, signup_options)
-        response = self._auth.do_post(uri, body)
+        response = self._http.post(uri, body=body)
         return Auth.extract_masked_address(response.json(), method)
 
     def sign_up_or_in(
@@ -124,7 +124,7 @@ class OTP(AuthBase):
             login_id,
             login_options,
         )
-        response = self._auth.do_post(uri, body)
+        response = self._http.post(uri, body=body)
         return Auth.extract_masked_address(response.json(), method)
 
     def verify_code(
@@ -158,7 +158,7 @@ class OTP(AuthBase):
 
         uri = OTP._compose_verify_code_url(method)
         body = OTP._compose_verify_code_body(login_id, code)
-        response = self._auth.do_post(uri, body, None)
+        response = self._http.post(uri, body=body)
 
         resp = response.json()
         jwt_response = self._auth.generate_jwt_response(
@@ -206,7 +206,7 @@ class OTP(AuthBase):
             template_id,
             provider_id,
         )
-        response = self._auth.do_post(uri, body, None, refresh_token)
+        response = self._http.post(uri, body=body, pswd=refresh_token)
         return Auth.extract_masked_address(response.json(), DeliveryMethod.EMAIL)
 
     def update_user_phone(
@@ -254,7 +254,7 @@ class OTP(AuthBase):
             template_id,
             provider_id,
         )
-        response = self._auth.do_post(uri, body, None, refresh_token)
+        response = self._http.post(uri, body=body, pswd=refresh_token)
         return Auth.extract_masked_address(response.json(), method)
 
     @staticmethod

--- a/descope/authmethod/password.py
+++ b/descope/authmethod/password.py
@@ -46,7 +46,7 @@ class Password(AuthBase):
 
         uri = EndpointsV1.sign_up_password_path
         body = Password._compose_signup_body(login_id, password, user)
-        response = self._auth.do_post(uri, body)
+        response = self._http.post(uri, body=body)
 
         resp = response.json()
         jwt_response = self._auth.generate_jwt_response(
@@ -87,7 +87,9 @@ class Password(AuthBase):
             )
 
         uri = EndpointsV1.sign_in_password_path
-        response = self._auth.do_post(uri, {"loginId": login_id, "password": password})
+        response = self._http.post(
+            uri, body={"loginId": login_id, "password": password}
+        )
 
         resp = response.json()
         jwt_response = self._auth.generate_jwt_response(
@@ -135,10 +137,7 @@ class Password(AuthBase):
         if template_options is not None:
             body["templateOptions"] = template_options
 
-        response = self._auth.do_post(
-            uri,
-            body,
-        )
+        response = self._http.post(uri, body=body)
 
         return response.json()
 
@@ -171,8 +170,10 @@ class Password(AuthBase):
             )
 
         uri = EndpointsV1.update_password_path
-        self._auth.do_post(
-            uri, {"loginId": login_id, "newPassword": new_password}, None, refresh_token
+        self._http.post(
+            uri,
+            body={"loginId": login_id, "newPassword": new_password},
+            pswd=refresh_token,
         )
 
     def replace(
@@ -217,9 +218,9 @@ class Password(AuthBase):
             )
 
         uri = EndpointsV1.replace_password_path
-        response = self._auth.do_post(
+        response = self._http.post(
             uri,
-            {
+            body={
                 "loginId": login_id,
                 "oldPassword": old_password,
                 "newPassword": new_password,
@@ -250,7 +251,7 @@ class Password(AuthBase):
         AuthException: raised if get policy operation fails
         """
 
-        response = self._auth.do_get(uri=EndpointsV1.password_policy_path)
+        response = self._http.get(uri=EndpointsV1.password_policy_path)
         return response.json()
 
     @staticmethod

--- a/descope/authmethod/saml.py
+++ b/descope/authmethod/saml.py
@@ -31,8 +31,11 @@ class SAML(AuthBase):
 
         uri = EndpointsV1.auth_saml_start_path
         params = SAML._compose_start_params(tenant, return_url)
-        response = self._auth.do_post(
-            uri, login_options.__dict__ if login_options else {}, params, refresh_token
+        response = self._http.post(
+            uri,
+            body=login_options.__dict__ if login_options else {},
+            params=params,
+            pswd=refresh_token,
         )
 
         return response.json()

--- a/descope/authmethod/sso.py
+++ b/descope/authmethod/sso.py
@@ -36,8 +36,11 @@ class SSO(AuthBase):
             prompt if prompt else "",
             sso_id if sso_id else "",
         )
-        response = self._auth.do_post(
-            uri, login_options.__dict__ if login_options else {}, params, refresh_token
+        response = self._http.post(
+            uri,
+            body=login_options.__dict__ if login_options else {},
+            params=params,
+            pswd=refresh_token,
         )
 
         return response.json()

--- a/descope/authmethod/totp.py
+++ b/descope/authmethod/totp.py
@@ -39,7 +39,7 @@ class TOTP(AuthBase):
 
         uri = EndpointsV1.sign_up_auth_totp_path
         body = TOTP._compose_signup_body(login_id, user)
-        response = self._auth.do_post(uri, body)
+        response = self._http.post(uri, body=body)
 
         return response.json()
 
@@ -83,7 +83,7 @@ class TOTP(AuthBase):
 
         uri = EndpointsV1.verify_totp_path
         body = TOTP._compose_signin_body(login_id, code, login_options)
-        response = self._auth.do_post(uri, body, None, refresh_token)
+        response = self._http.post(uri, body=body, pswd=refresh_token)
 
         resp = response.json()
         jwt_response = self._auth.generate_jwt_response(
@@ -122,7 +122,7 @@ class TOTP(AuthBase):
 
         uri = EndpointsV1.update_totp_path
         body = TOTP._compose_update_user_body(login_id)
-        response = self._auth.do_post(uri, body, None, refresh_token)
+        response = self._http.post(uri, body=body, pswd=refresh_token)
 
         return response.json()
 

--- a/descope/authmethod/webauthn.py
+++ b/descope/authmethod/webauthn.py
@@ -37,8 +37,7 @@ class WebAuthn(AuthBase):
 
         uri = EndpointsV1.sign_up_auth_webauthn_start_path
         body = WebAuthn._compose_sign_up_start_body(login_id, user, origin)
-        response = self._auth.do_post(uri, body)
-
+        response = self._http.post(uri, body=body)
         return response.json()
 
     def sign_up_finish(
@@ -59,11 +58,9 @@ class WebAuthn(AuthBase):
             raise AuthException(
                 400, ERROR_TYPE_INVALID_ARGUMENT, "Response cannot be empty"
             )
-
         uri = EndpointsV1.sign_up_auth_webauthn_finish_path
         body = WebAuthn._compose_sign_up_in_finish_body(transaction_id, response)
-        response = self._auth.do_post(uri, body, None, "")
-
+        response = self._http.post(uri, body=body)
         resp = response.json()
         jwt_response = self._auth.generate_jwt_response(
             resp, response.cookies.get(REFRESH_SESSION_COOKIE_NAME, None), audience
@@ -94,8 +91,7 @@ class WebAuthn(AuthBase):
 
         uri = EndpointsV1.sign_in_auth_webauthn_start_path
         body = WebAuthn._compose_sign_in_start_body(login_id, origin, login_options)
-        response = self._auth.do_post(uri, body, pswd=refresh_token)
-
+        response = self._http.post(uri, body=body, pswd=refresh_token)
         return response.json()
 
     def sign_in_finish(
@@ -119,8 +115,7 @@ class WebAuthn(AuthBase):
 
         uri = EndpointsV1.sign_in_auth_webauthn_finish_path
         body = WebAuthn._compose_sign_up_in_finish_body(transaction_id, response)
-        response = self._auth.do_post(uri, body, None)
-
+        response = self._http.post(uri, body=body)
         resp = response.json()
         jwt_response = self._auth.generate_jwt_response(
             resp, response.cookies.get(REFRESH_SESSION_COOKIE_NAME, None), audience
@@ -147,8 +142,7 @@ class WebAuthn(AuthBase):
 
         uri = EndpointsV1.sign_up_or_in_auth_webauthn_start_path
         body = WebAuthn._compose_sign_up_or_in_start_body(login_id, origin)
-        response = self._auth.do_post(uri, body)
-
+        response = self._http.post(uri, body=body)
         return response.json()
 
     def update_start(self, login_id: str, refresh_token: str, origin: str):
@@ -167,8 +161,7 @@ class WebAuthn(AuthBase):
 
         uri = EndpointsV1.update_auth_webauthn_start_path
         body = WebAuthn._compose_update_start_body(login_id, origin)
-        response = self._auth.do_post(uri, body, None, refresh_token)
-
+        response = self._http.post(uri, body=body, pswd=refresh_token)
         return response.json()
 
     def update_finish(self, transaction_id: str, response: str) -> None:
@@ -187,7 +180,7 @@ class WebAuthn(AuthBase):
 
         uri = EndpointsV1.update_auth_webauthn_finish_path
         body = WebAuthn._compose_update_finish_body(transaction_id, response)
-        self._auth.do_post(uri, body)
+        self._http.post(uri, body=body)
 
     @staticmethod
     def _compose_sign_up_start_body(login_id: str, user: dict, origin: str) -> dict:

--- a/descope/common.py
+++ b/descope/common.py
@@ -184,3 +184,20 @@ def signup_options_to_dict(signup_options: Optional[SignUpOptions] = None) -> di
         if signup_options.revokeOtherSessions is not None:
             res["revokeOtherSessions"] = signup_options.revokeOtherSessions
     return res
+
+
+def get_method_string(method: DeliveryMethod) -> str:
+    name = {
+        DeliveryMethod.EMAIL: "email",
+        DeliveryMethod.SMS: "sms",
+        DeliveryMethod.VOICE: "voice",
+        DeliveryMethod.WHATSAPP: "whatsapp",
+        DeliveryMethod.EMBEDDED: "Embedded",
+    }.get(method)
+
+    if not name:
+        raise AuthException(
+            400, ERROR_TYPE_INVALID_ARGUMENT, f"Unknown delivery method: {method}"
+        )
+
+    return name

--- a/descope/http_client.py
+++ b/descope/http_client.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import os
+import platform
+from http import HTTPStatus
+
+try:
+    from importlib.metadata import version
+except ImportError:
+    from pkg_resources import get_distribution
+
+import requests
+
+from descope.common import (
+    DEFAULT_BASE_URL,
+    DEFAULT_DOMAIN,
+    DEFAULT_TIMEOUT_SECONDS,
+    DEFAULT_URL_PREFIX,
+)
+from descope.exceptions import (
+    API_RATE_LIMIT_RETRY_AFTER_HEADER,
+    ERROR_TYPE_API_RATE_LIMIT,
+    ERROR_TYPE_SERVER_ERROR,
+    AuthException,
+    RateLimitException,
+)
+
+
+def sdk_version():
+    try:
+        return version("descope")  # type: ignore
+    except NameError:  # pragma: no cover
+        return get_distribution("descope").version  # type: ignore
+
+
+_default_headers = {
+    "Content-Type": "application/json",
+    "x-descope-sdk-name": "python",
+    "x-descope-sdk-python-version": platform.python_version(),
+    "x-descope-sdk-version": sdk_version(),
+}
+
+
+class HTTPClient:
+    def __init__(
+        self,
+        project_id: str,
+        base_url: str | None = None,
+        *,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        secure: bool = True,
+        management_key: str | None = None,
+    ) -> None:
+        if not project_id:
+            raise AuthException(
+                400,
+                ERROR_TYPE_SERVER_ERROR,
+                "Project ID is required to initialize HTTP client",
+            )
+
+        # Prefer explicitly provided base_url, then env var, then computed default
+        env_base = os.getenv("DESCOPE_BASE_URI")
+        self.base_url = base_url or env_base or self.base_url_for_project_id(project_id)
+
+        self.project_id = project_id
+        self.timeout_seconds = timeout_seconds
+        self.secure = secure
+        self.management_key = management_key
+
+    # ------------- public API -------------
+    def get(
+        self,
+        uri: str,
+        *,
+        params=None,
+        allow_redirects: bool | None = None,
+        pswd: str | None = None,
+    ) -> requests.Response:
+        response = requests.get(
+            f"{self.base_url}{uri}",
+            headers=self._get_default_headers(pswd),
+            params=params,
+            allow_redirects=allow_redirects,
+            verify=self.secure,
+            timeout=self.timeout_seconds,
+        )
+        self._raise_from_response(response)
+        return response
+
+    def post(
+        self,
+        uri: str,
+        *,
+        body: dict | list[dict] | list[str] | None = None,
+        params=None,
+        pswd: str | None = None,
+    ) -> requests.Response:
+        response = requests.post(
+            f"{self.base_url}{uri}",
+            headers=self._get_default_headers(pswd),
+            json=body,
+            allow_redirects=False,
+            verify=self.secure,
+            params=params,
+            timeout=self.timeout_seconds,
+        )
+        self._raise_from_response(response)
+        return response
+
+    def patch(
+        self,
+        uri: str,
+        *,
+        body: dict | list[dict] | list[str] | None,
+        params=None,
+        pswd: str | None = None,
+    ) -> requests.Response:
+        response = requests.patch(
+            f"{self.base_url}{uri}",
+            headers=self._get_default_headers(pswd),
+            json=body,
+            allow_redirects=False,
+            verify=self.secure,
+            params=params,
+            timeout=self.timeout_seconds,
+        )
+        self._raise_from_response(response)
+        return response
+
+    def delete(
+        self,
+        uri: str,
+        *,
+        params=None,
+        pswd: str | None = None,
+    ) -> requests.Response:
+        response = requests.delete(
+            f"{self.base_url}{uri}",
+            params=params,
+            headers=self._get_default_headers(pswd),
+            allow_redirects=False,
+            verify=self.secure,
+            timeout=self.timeout_seconds,
+        )
+        self._raise_from_response(response)
+        return response
+
+    def get_default_headers(self, pswd: str | None = None) -> dict:
+        return self._get_default_headers(pswd)
+
+    # ------------- helpers -------------
+    @staticmethod
+    def base_url_for_project_id(project_id: str) -> str:
+        if len(project_id) >= 32:
+            region = project_id[1:5]
+            return ".".join([DEFAULT_URL_PREFIX, region, DEFAULT_DOMAIN])
+        return DEFAULT_BASE_URL
+
+    def _parse_retry_after(self, headers) -> int:
+        try:
+            return int(headers.get(API_RATE_LIMIT_RETRY_AFTER_HEADER, 0))
+        except (ValueError, TypeError):
+            return 0
+
+    def _raise_rate_limit_exception(self, response):
+        try:
+            resp = response.json()
+            raise RateLimitException(
+                resp.get("errorCode", HTTPStatus.TOO_MANY_REQUESTS),
+                ERROR_TYPE_API_RATE_LIMIT,
+                resp.get("errorDescription", ""),
+                resp.get("errorMessage", ""),
+                rate_limit_parameters={
+                    API_RATE_LIMIT_RETRY_AFTER_HEADER: self._parse_retry_after(
+                        response.headers
+                    )
+                },
+            )
+        except RateLimitException:
+            raise
+        except Exception:
+            raise RateLimitException(
+                status_code=HTTPStatus.TOO_MANY_REQUESTS,
+                error_type=ERROR_TYPE_API_RATE_LIMIT,
+                error_message=ERROR_TYPE_API_RATE_LIMIT,
+                error_description=ERROR_TYPE_API_RATE_LIMIT,
+            )
+
+    def _raise_from_response(self, response):
+        if response.ok:
+            return
+        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+            self._raise_rate_limit_exception(response)
+        raise AuthException(
+            response.status_code,
+            ERROR_TYPE_SERVER_ERROR,
+            response.text,
+        )
+
+    def _get_default_headers(self, pswd: str | None = None):
+        headers = _default_headers.copy()
+        headers["x-descope-project-id"] = self.project_id
+        bearer = self.project_id
+        if pswd:
+            bearer = f"{self.project_id}:{pswd}"
+        if self.management_key:
+            bearer = f"{bearer}:{self.management_key}"
+        headers["Authorization"] = f"Bearer {bearer}"
+        return headers

--- a/descope/jwt_common.py
+++ b/descope/jwt_common.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from typing import Callable, Iterable, Optional
+
+import jwt
+
+from descope.common import (
+    COOKIE_DATA_NAME,
+    REFRESH_SESSION_TOKEN_NAME,
+    SESSION_TOKEN_NAME,
+)
+
+
+def adjust_properties(jwt_response: dict, user_jwt: bool) -> dict:
+    """Normalize top-level fields on a JWT response.
+
+    Copies permissions/roles/tenants from present token claims (session or refresh)
+    to the top-level and sets projectId and userId/keyId for convenience.
+    """
+    # Save permissions, roles and tenants info from Session token or from refresh token on the json top level
+    if SESSION_TOKEN_NAME in jwt_response:
+        jwt_response["permissions"] = jwt_response[SESSION_TOKEN_NAME].get(
+            "permissions", []
+        )
+        jwt_response["roles"] = jwt_response[SESSION_TOKEN_NAME].get("roles", [])
+        jwt_response["tenants"] = jwt_response[SESSION_TOKEN_NAME].get("tenants", {})
+    elif REFRESH_SESSION_TOKEN_NAME in jwt_response:
+        jwt_response["permissions"] = jwt_response[REFRESH_SESSION_TOKEN_NAME].get(
+            "permissions", []
+        )
+        jwt_response["roles"] = jwt_response[REFRESH_SESSION_TOKEN_NAME].get(
+            "roles", []
+        )
+        jwt_response["tenants"] = jwt_response[REFRESH_SESSION_TOKEN_NAME].get(
+            "tenants", {}
+        )
+    else:
+        jwt_response["permissions"] = jwt_response.get("permissions", [])
+        jwt_response["roles"] = jwt_response.get("roles", [])
+        jwt_response["tenants"] = jwt_response.get("tenants", {})
+
+    # Save the projectID also in the dict top level
+    issuer = (
+        jwt_response.get(SESSION_TOKEN_NAME, {}).get("iss", None)
+        or jwt_response.get(REFRESH_SESSION_TOKEN_NAME, {}).get("iss", None)
+        or jwt_response.get("iss", "")
+    )
+    jwt_response["projectId"] = issuer.rsplit("/")[
+        -1
+    ]  # support both url issuer and project ID issuer
+
+    sub = (
+        jwt_response.get(SESSION_TOKEN_NAME, {}).get("dsub", None)
+        or jwt_response.get(SESSION_TOKEN_NAME, {}).get("sub", None)
+        or jwt_response.get(REFRESH_SESSION_TOKEN_NAME, {}).get("dsub", None)
+        or jwt_response.get(REFRESH_SESSION_TOKEN_NAME, {}).get("sub", None)
+        or jwt_response.get("sub", "")
+    )
+    if user_jwt:
+        # Save the userID also in the dict top level
+        jwt_response["userId"] = sub
+    else:
+        # Save the AccessKeyID also in the dict top level
+        jwt_response["keyId"] = sub
+
+    return jwt_response
+
+
+def decode_token_unverified(
+    token: str, audience: Optional[str | Iterable[str]] = None
+) -> dict:
+    """Decode a JWT without verifying signature (used when no validator is provided).
+
+    Audience verification is disabled by default since no key is provided.
+    Returns an empty dict if decoding fails.
+    """
+    try:
+        return jwt.decode(
+            token, options={"verify_signature": False, "verify_aud": False}
+        )
+    except Exception:
+        return {}
+
+
+def generate_auth_info(
+    response_body: dict,
+    refresh_token: Optional[str],
+    user_jwt: bool,
+    audience: Optional[str | Iterable[str]] = None,
+    token_validator: Optional[
+        Callable[[str, Optional[str | Iterable[str]]], dict]
+    ] = None,
+) -> dict:
+    """Build the normalized JWT info dict using a provided token validator.
+
+    token_validator should accept (token, audience) and return decoded claims dict.
+    If not provided, tokens will be decoded without signature verification.
+    """
+    if token_validator is None:
+        token_validator = decode_token_unverified
+
+    jwt_response: dict = {}
+
+    st_jwt = response_body.get("sessionJwt", "")
+    if st_jwt:
+        jwt_response[SESSION_TOKEN_NAME] = token_validator(st_jwt, audience)
+
+    rt_jwt = response_body.get("refreshJwt", "")
+    if rt_jwt:
+        jwt_response[REFRESH_SESSION_TOKEN_NAME] = token_validator(rt_jwt, audience)
+    elif refresh_token:
+        jwt_response[REFRESH_SESSION_TOKEN_NAME] = token_validator(
+            refresh_token, audience
+        )
+
+    jwt_response = adjust_properties(jwt_response, user_jwt)
+
+    if user_jwt:
+        jwt_response[COOKIE_DATA_NAME] = {
+            "exp": response_body.get("cookieExpiration", 0),
+            "maxAge": response_body.get("cookieMaxAge", 0),
+            "domain": response_body.get("cookieDomain", ""),
+            "path": response_body.get("cookiePath", "/"),
+        }
+
+    return jwt_response
+
+
+def generate_jwt_response(
+    response_body: dict,
+    refresh_cookie: Optional[str],
+    audience: Optional[str | Iterable[str]] = None,
+    token_validator: Optional[
+        Callable[[str, Optional[str | Iterable[str]]], dict]
+    ] = None,
+) -> dict:
+    """Compose the final JWT response body using the provided token validator."""
+    jwt_response = generate_auth_info(
+        response_body, refresh_cookie, True, audience, token_validator
+    )
+    jwt_response["user"] = response_body.get("user", {})
+    jwt_response["firstSeen"] = response_body.get("firstSeen", True)
+    return jwt_response

--- a/descope/management/access_key.py
+++ b/descope/management/access_key.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from descope._auth_base import AuthBase
+from descope._http_base import HTTPBase
 from descope.management.common import (
     AssociatedTenant,
     MgmtV1,
@@ -8,7 +8,7 @@ from descope.management.common import (
 )
 
 
-class AccessKey(AuthBase):
+class AccessKey(HTTPBase):
     def create(
         self,
         name: str,
@@ -51,9 +51,9 @@ class AccessKey(AuthBase):
         role_names = [] if role_names is None else role_names
         key_tenants = [] if key_tenants is None else key_tenants
 
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.access_key_create_path,
-            AccessKey._compose_create_body(
+            body=AccessKey._compose_create_body(
                 name,
                 expire_time,
                 role_names,
@@ -63,7 +63,6 @@ class AccessKey(AuthBase):
                 description,
                 permitted_ips,
             ),
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -85,10 +84,9 @@ class AccessKey(AuthBase):
         Raise:
         AuthException: raised if load operation fails
         """
-        response = self._auth.do_get(
+        response = self._http.get(
             uri=MgmtV1.access_key_load_path,
             params={"id": id},
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -112,10 +110,9 @@ class AccessKey(AuthBase):
         """
         tenant_ids = [] if tenant_ids is None else tenant_ids
 
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.access_keys_search_path,
-            {"tenantIds": tenant_ids},
-            pswd=self._auth.management_key,
+            body={"tenantIds": tenant_ids},
         )
         return response.json()
 
@@ -136,10 +133,9 @@ class AccessKey(AuthBase):
         Raise:
         AuthException: raised if update operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.access_key_update_path,
-            {"id": id, "name": name, "description": description},
-            pswd=self._auth.management_key,
+            body={"id": id, "name": name, "description": description},
         )
 
     def deactivate(
@@ -156,10 +152,9 @@ class AccessKey(AuthBase):
         Raise:
         AuthException: raised if deactivation operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.access_key_deactivate_path,
-            {"id": id},
-            pswd=self._auth.management_key,
+            body={"id": id},
         )
 
     def activate(
@@ -176,10 +171,9 @@ class AccessKey(AuthBase):
         Raise:
         AuthException: raised if activation operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.access_key_activate_path,
-            {"id": id},
-            pswd=self._auth.management_key,
+            body={"id": id},
         )
 
     def delete(
@@ -195,10 +189,9 @@ class AccessKey(AuthBase):
         Raise:
         AuthException: raised if creation operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.access_key_delete_path,
-            {"id": id},
-            pswd=self._auth.management_key,
+            body={"id": id},
         )
 
     @staticmethod

--- a/descope/management/audit.py
+++ b/descope/management/audit.py
@@ -1,11 +1,11 @@
 from datetime import datetime
 from typing import Any, List, Optional
 
-from descope._auth_base import AuthBase
+from descope._http_base import HTTPBase
 from descope.management.common import MgmtV1
 
 
-class Audit(AuthBase):
+class Audit(HTTPBase):
     def search(
         self,
         user_ids: Optional[List[str]] = None,
@@ -91,11 +91,7 @@ class Audit(AuthBase):
         if to_ts is not None:
             body["to"] = int(to_ts.timestamp() * 1000)
 
-        response = self._auth.do_post(
-            MgmtV1.audit_search,
-            body=body,
-            pswd=self._auth.management_key,
-        )
+        response = self._http.post(MgmtV1.audit_search, body=body)
         return {
             "audits": list(map(Audit._convert_audit_record, response.json()["audits"]))
         }
@@ -134,11 +130,7 @@ class Audit(AuthBase):
         if data is not None:
             body["data"] = data
 
-        self._auth.do_post(
-            MgmtV1.audit_create_event,
-            body=body,
-            pswd=self._auth.management_key,
-        )
+        self._http.post(MgmtV1.audit_create_event, body=body)
 
     @staticmethod
     def _convert_audit_record(a: dict) -> dict:

--- a/descope/management/authz.py
+++ b/descope/management/authz.py
@@ -1,11 +1,11 @@
 from datetime import datetime, timezone
 from typing import Any, List, Optional
 
-from descope._auth_base import AuthBase
+from descope._http_base import HTTPBase
 from descope.management.common import MgmtV1
 
 
-class Authz(AuthBase):
+class Authz(HTTPBase):
     def save_schema(self, schema: dict, upgrade: bool = False):
         """
         Create or update the ReBAC schema.
@@ -40,10 +40,9 @@ class Authz(AuthBase):
         Raise:
         AuthException: raised if saving fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.authz_schema_save,
-            {"schema": schema, "upgrade": upgrade},
-            pswd=self._auth.management_key,
+            body={"schema": schema, "upgrade": upgrade},
         )
 
     def delete_schema(self):
@@ -52,10 +51,8 @@ class Authz(AuthBase):
         Raise:
         AuthException: raised if delete schema fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.authz_schema_delete,
-            None,
-            pswd=self._auth.management_key,
         )
 
     def load_schema(self) -> dict:
@@ -66,10 +63,8 @@ class Authz(AuthBase):
         Raise:
         AuthException: raised if load schema fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.authz_schema_load,
-            None,
-            pswd=self._auth.management_key,
         )
         return response.json()["schema"]
 
@@ -91,10 +86,9 @@ class Authz(AuthBase):
             body["oldName"] = old_name
         if schema_name != "":
             body["schemaName"] = schema_name
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.authz_ns_save,
-            body,
-            pswd=self._auth.management_key,
+            body=body,
         )
 
     def delete_namespace(self, name: str, schema_name: str = ""):
@@ -109,10 +103,9 @@ class Authz(AuthBase):
         body: dict[str, Any] = {"name": name}
         if schema_name != "":
             body["schemaName"] = schema_name
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.authz_ns_delete,
-            body,
-            pswd=self._auth.management_key,
+            body=body,
         )
 
     def save_relation_definition(
@@ -141,10 +134,9 @@ class Authz(AuthBase):
             body["oldName"] = old_name
         if schema_name != "":
             body["schemaName"] = schema_name
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.authz_rd_save,
-            body,
-            pswd=self._auth.management_key,
+            body=body,
         )
 
     def delete_relation_definition(
@@ -162,10 +154,9 @@ class Authz(AuthBase):
         body: dict[str, Any] = {"name": name, "namespace": namespace}
         if schema_name != "":
             body["schemaName"] = schema_name
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.authz_rd_delete,
-            body,
-            pswd=self._auth.management_key,
+            body=body,
         )
 
     def create_relations(
@@ -202,12 +193,9 @@ class Authz(AuthBase):
         Raise:
         AuthException: raised if create relations fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.authz_re_create,
-            {
-                "relations": relations,
-            },
-            pswd=self._auth.management_key,
+            body={"relations": relations},
         )
 
     def delete_relations(
@@ -221,12 +209,9 @@ class Authz(AuthBase):
         Raise:
         AuthException: raised if delete relations fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.authz_re_delete,
-            {
-                "relations": relations,
-            },
-            pswd=self._auth.management_key,
+            body={"relations": relations},
         )
 
     def delete_relations_for_resources(
@@ -240,12 +225,9 @@ class Authz(AuthBase):
         Raise:
         AuthException: raised if delete relations for resources fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.authz_re_delete_resources,
-            {
-                "resources": resources,
-            },
-            pswd=self._auth.management_key,
+            body={"resources": resources},
         )
 
     def has_relations(
@@ -277,12 +259,9 @@ class Authz(AuthBase):
         Raise:
         AuthException: raised if query fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.authz_re_has_relations,
-            {
-                "relationQueries": relation_queries,
-            },
-            pswd=self._auth.management_key,
+            body={"relationQueries": relation_queries},
         )
         return response.json()["relationQueries"]
 
@@ -300,14 +279,13 @@ class Authz(AuthBase):
         Raise:
         AuthException: raised if query fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.authz_re_who,
-            {
+            body={
                 "resource": resource,
                 "relationDefinition": relation_definition,
                 "namespace": namespace,
             },
-            pswd=self._auth.management_key,
         )
         return response.json()["targets"]
 
@@ -322,10 +300,9 @@ class Authz(AuthBase):
         Raise:
         AuthException: raised if query fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.authz_re_resource,
-            {"resource": resource},
-            pswd=self._auth.management_key,
+            body={"resource": resource},
         )
         return response.json()["relations"]
 
@@ -340,10 +317,9 @@ class Authz(AuthBase):
         Raise:
         AuthException: raised if query fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.authz_re_targets,
-            {"targets": targets},
-            pswd=self._auth.management_key,
+            body={"targets": targets},
         )
         return response.json()["relations"]
 
@@ -358,10 +334,9 @@ class Authz(AuthBase):
         Raise:
         AuthException: raised if query fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.authz_re_target_all,
-            {"target": target},
-            pswd=self._auth.management_key,
+            body={"target": target},
         )
         return response.json()["relations"]
 
@@ -380,14 +355,13 @@ class Authz(AuthBase):
         Raise:
         AuthException: raised if query fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.authz_re_target_with_relation,
-            {
+            body={
                 "target": target,
                 "relationDefinition": relation_definition,
                 "namespace": namespace,
             },
-            pswd=self._auth.management_key,
         )
         return response.json()["relations"]
 
@@ -402,15 +376,14 @@ class Authz(AuthBase):
         Raise:
         AuthException: raised if query fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.authz_get_modified,
-            {
+            body={
                 "since": (
                     int(since.replace(tzinfo=timezone.utc).timestamp() * 1000)
                     if since
                     else 0
                 )
             },
-            pswd=self._auth.management_key,
         )
         return response.json()["relations"]

--- a/descope/management/fga.py
+++ b/descope/management/fga.py
@@ -1,10 +1,10 @@
 from typing import List
 
-from descope._auth_base import AuthBase
+from descope._http_base import HTTPBase
 from descope.management.common import MgmtV1
 
 
-class FGA(AuthBase):
+class FGA(HTTPBase):
     def save_schema(self, schema: str):
         """
         Create or update an FGA schema.
@@ -40,10 +40,9 @@ class FGA(AuthBase):
         Raise:
         AuthException: raised if saving fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.fga_save_schema,
-            {"dsl": schema},
-            pswd=self._auth.management_key,
+            body={"dsl": schema},
         )
 
     def create_relations(
@@ -64,12 +63,9 @@ class FGA(AuthBase):
         Raise:
         AuthException: raised if create relations fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.fga_create_relations,
-            {
-                "tuples": relations,
-            },
-            pswd=self._auth.management_key,
+            body={"tuples": relations},
         )
 
     def delete_relations(
@@ -83,12 +79,9 @@ class FGA(AuthBase):
         Raise:
         AuthException: raised if delete relations fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.fga_delete_relations,
-            {
-                "tuples": relations,
-            },
-            pswd=self._auth.management_key,
+            body={"tuples": relations},
         )
 
     def check(
@@ -124,12 +117,9 @@ class FGA(AuthBase):
         Raise:
         AuthException: raised if query fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.fga_check,
-            {
-                "tuples": relations,
-            },
-            pswd=self._auth.management_key,
+            body={"tuples": relations},
         )
         return list(
             map(
@@ -146,10 +136,9 @@ class FGA(AuthBase):
         Returns:
             List[dict]: list of resources details as returned by the server.
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.fga_resources_load,
-            {"resourceIdentifiers": resource_identifiers},
-            pswd=self._auth.management_key,
+            body={"resourceIdentifiers": resource_identifiers},
         )
         return response.json().get("resourcesDetails", [])
 
@@ -159,8 +148,7 @@ class FGA(AuthBase):
         Args:
             resources_details (List[dict]): list of dicts each containing 'resourceId' and 'resourceType' plus optionally containing metadata fields such as 'displayName'.
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.fga_resources_save,
-            {"resourcesDetails": resources_details},
-            pswd=self._auth.management_key,
+            body={"resourcesDetails": resources_details},
         )

--- a/descope/management/flow.py
+++ b/descope/management/flow.py
@@ -1,10 +1,10 @@
 from typing import List
 
-from descope._auth_base import AuthBase
+from descope._http_base import HTTPBase
 from descope.management.common import MgmtV1
 
 
-class Flow(AuthBase):
+class Flow(HTTPBase):
     def list_flows(
         self,
     ) -> dict:
@@ -18,11 +18,7 @@ class Flow(AuthBase):
         Raise:
         AuthException: raised if list operation fails
         """
-        response = self._auth.do_post(
-            MgmtV1.flow_list_path,
-            None,
-            pswd=self._auth.management_key,
-        )
+        response = self._http.post(MgmtV1.flow_list_path)
         return response.json()
 
     def delete_flows(
@@ -38,12 +34,11 @@ class Flow(AuthBase):
         Raise:
         AuthException: raised if delete operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.flow_delete_path,
-            {
+            body={
                 "ids": flow_ids,
             },
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -64,12 +59,11 @@ class Flow(AuthBase):
         Raise:
         AuthException: raised if export operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.flow_export_path,
-            {
+            body={
                 "flowId": flow_id,
             },
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -97,14 +91,13 @@ class Flow(AuthBase):
         Raise:
         AuthException: raised if import operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.flow_import_path,
-            {
+            body={
                 "flowId": flow_id,
                 "flow": flow,
                 "screens": screens,
             },
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -121,10 +114,9 @@ class Flow(AuthBase):
         Raise:
         AuthException: raised if export operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.theme_export_path,
-            {},
-            pswd=self._auth.management_key,
+            body={},
         )
         return response.json()
 
@@ -147,11 +139,10 @@ class Flow(AuthBase):
         Raise:
         AuthException: raised if import operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.theme_import_path,
-            {
+            body={
                 "theme": theme,
             },
-            pswd=self._auth.management_key,
         )
         return response.json()

--- a/descope/management/group.py
+++ b/descope/management/group.py
@@ -1,10 +1,10 @@
 from typing import List, Optional
 
-from descope._auth_base import AuthBase
+from descope._http_base import HTTPBase
 from descope.management.common import MgmtV1
 
 
-class Group(AuthBase):
+class Group(HTTPBase):
     def load_all_groups(
         self,
         tenant_id: str,
@@ -35,12 +35,11 @@ class Group(AuthBase):
         Raise:
         AuthException: raised if load operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.group_load_all_path,
-            {
+            body={
                 "tenantId": tenant_id,
             },
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -81,14 +80,13 @@ class Group(AuthBase):
         user_ids = [] if user_ids is None else user_ids
         login_ids = [] if login_ids is None else login_ids
 
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.group_load_all_for_member_path,
-            {
+            body={
                 "tenantId": tenant_id,
                 "loginIds": login_ids,
                 "userIds": user_ids,
             },
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -124,12 +122,11 @@ class Group(AuthBase):
         Raise:
         AuthException: raised if load operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.group_load_all_group_members_path,
-            {
+            body={
                 "tenantId": tenant_id,
                 "groupId": group_id,
             },
-            pswd=self._auth.management_key,
         )
         return response.json()

--- a/descope/management/permission.py
+++ b/descope/management/permission.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
-from descope._auth_base import AuthBase
+from descope._http_base import HTTPBase
 from descope.management.common import MgmtV1
 
 
-class Permission(AuthBase):
+class Permission(HTTPBase):
     def create(
         self,
         name: str,
@@ -20,10 +20,9 @@ class Permission(AuthBase):
         Raise:
         AuthException: raised if creation operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.permission_create_path,
-            {"name": name, "description": description},
-            pswd=self._auth.management_key,
+            body={"name": name, "description": description},
         )
 
     def update(
@@ -44,10 +43,9 @@ class Permission(AuthBase):
         Raise:
         AuthException: raised if update operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.permission_update_path,
-            {"name": name, "newName": new_name, "description": description},
-            pswd=self._auth.management_key,
+            body={"name": name, "newName": new_name, "description": description},
         )
 
     def delete(
@@ -63,10 +61,9 @@ class Permission(AuthBase):
         Raise:
         AuthException: raised if creation operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.permission_delete_path,
-            {"name": name},
-            pswd=self._auth.management_key,
+            body={"name": name},
         )
 
     def load_all(
@@ -83,8 +80,7 @@ class Permission(AuthBase):
         Raise:
         AuthException: raised if load operation fails
         """
-        response = self._auth.do_get(
-            uri=MgmtV1.permission_load_all_path,
-            pswd=self._auth.management_key,
+        response = self._http.get(
+            MgmtV1.permission_load_all_path,
         )
         return response.json()

--- a/descope/management/project.py
+++ b/descope/management/project.py
@@ -1,10 +1,10 @@
 from typing import List, Optional
 
-from descope._auth_base import AuthBase
+from descope._http_base import HTTPBase
 from descope.management.common import MgmtV1
 
 
-class Project(AuthBase):
+class Project(HTTPBase):
     def update_name(
         self,
         name: str,
@@ -17,12 +17,11 @@ class Project(AuthBase):
         Raise:
         AuthException: raised if operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.project_update_name,
-            {
+            body={
                 "name": name,
             },
-            pswd=self._auth.management_key,
         )
 
     def update_tags(
@@ -37,12 +36,11 @@ class Project(AuthBase):
         Raise:
         AuthException: raised if operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.project_update_tags,
-            {
+            body={
                 "tags": tags,
             },
-            pswd=self._auth.management_key,
         )
 
     def list_projects(
@@ -59,10 +57,9 @@ class Project(AuthBase):
         Raise:
         AuthException: raised if operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.project_list_projects,
-            {},
-            pswd=self._auth.management_key,
+            body={},
         )
         resp = response.json()
 
@@ -96,14 +93,13 @@ class Project(AuthBase):
         Raise:
         AuthException: raised if clone operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.project_clone,
-            {
+            body={
                 "name": name,
                 "environment": environment,
                 "tags": tags,
             },
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -123,10 +119,9 @@ class Project(AuthBase):
         Raise:
         AuthException: raised if export operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.project_export,
-            {},
-            pswd=self._auth.management_key,
+            body={},
         )
         return response.json()["files"]
 
@@ -147,12 +142,11 @@ class Project(AuthBase):
         Raise:
         AuthException: raised if import operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.project_import,
-            {
+            body={
                 "files": files,
             },
-            pswd=self._auth.management_key,
         )
         return
 

--- a/descope/management/role.py
+++ b/descope/management/role.py
@@ -1,10 +1,10 @@
 from typing import List, Optional
 
-from descope._auth_base import AuthBase
+from descope._http_base import HTTPBase
 from descope.management.common import MgmtV1
 
 
-class Role(AuthBase):
+class Role(HTTPBase):
     def create(
         self,
         name: str,
@@ -28,16 +28,15 @@ class Role(AuthBase):
         """
         permission_names = [] if permission_names is None else permission_names
 
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.role_create_path,
-            {
+            body={
                 "name": name,
                 "description": description,
                 "permissionNames": permission_names,
                 "tenantId": tenant_id,
                 "default": default,
             },
-            pswd=self._auth.management_key,
         )
 
     def update(
@@ -65,9 +64,9 @@ class Role(AuthBase):
         AuthException: raised if update operation fails
         """
         permission_names = [] if permission_names is None else permission_names
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.role_update_path,
-            {
+            body={
                 "name": name,
                 "newName": new_name,
                 "description": description,
@@ -75,7 +74,6 @@ class Role(AuthBase):
                 "tenantId": tenant_id,
                 "default": default,
             },
-            pswd=self._auth.management_key,
         )
 
     def delete(
@@ -92,10 +90,9 @@ class Role(AuthBase):
         Raise:
         AuthException: raised if creation operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.role_delete_path,
-            {"name": name, "tenantId": tenant_id},
-            pswd=self._auth.management_key,
+            body={"name": name, "tenantId": tenant_id},
         )
 
     def load_all(
@@ -112,9 +109,8 @@ class Role(AuthBase):
         Raise:
         AuthException: raised if load operation fails
         """
-        response = self._auth.do_get(
-            uri=MgmtV1.role_load_all_path,
-            pswd=self._auth.management_key,
+        response = self._http.get(
+            MgmtV1.role_load_all_path,
         )
         return response.json()
 
@@ -155,9 +151,8 @@ class Role(AuthBase):
         if include_project_roles is not None:
             body["includeProjectRoles"] = include_project_roles
 
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.role_search_path,
-            body,
-            pswd=self._auth.management_key,
+            body=body,
         )
         return response.json()

--- a/descope/management/sso_application.py
+++ b/descope/management/sso_application.py
@@ -1,6 +1,6 @@
 from typing import Any, List, Optional
 
-from descope._auth_base import AuthBase
+from descope._http_base import HTTPBase
 from descope.management.common import (
     MgmtV1,
     SAMLIDPAttributeMappingInfo,
@@ -10,7 +10,7 @@ from descope.management.common import (
 )
 
 
-class SSOApplication(AuthBase):
+class SSOApplication(HTTPBase):
     def create_oidc_application(
         self,
         name: str,
@@ -42,9 +42,9 @@ class SSOApplication(AuthBase):
         AuthException: raised if create operation fails
         """
         uri = MgmtV1.sso_application_oidc_create_path
-        response = self._auth.do_post(
+        response = self._http.post(
             uri,
-            SSOApplication._compose_create_update_oidc_body(
+            body=SSOApplication._compose_create_update_oidc_body(
                 name,
                 login_page_url,
                 id,
@@ -53,7 +53,6 @@ class SSOApplication(AuthBase):
                 enabled,
                 force_authentication,
             ),
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -128,9 +127,9 @@ class SSOApplication(AuthBase):
         )
 
         uri = MgmtV1.sso_application_saml_create_path
-        response = self._auth.do_post(
+        response = self._http.post(
             uri,
-            SSOApplication._compose_create_update_saml_body(
+            body=SSOApplication._compose_create_update_saml_body(
                 name,
                 login_page_url,
                 id,
@@ -151,7 +150,6 @@ class SSOApplication(AuthBase):
                 force_authentication,
                 logout_redirect_url,
             ),
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -183,9 +181,9 @@ class SSOApplication(AuthBase):
         """
 
         uri = MgmtV1.sso_application_oidc_update_path
-        self._auth.do_post(
+        self._http.post(
             uri,
-            SSOApplication._compose_create_update_oidc_body(
+            body=SSOApplication._compose_create_update_oidc_body(
                 name,
                 login_page_url,
                 id,
@@ -194,7 +192,6 @@ class SSOApplication(AuthBase):
                 enabled,
                 force_authentication,
             ),
-            pswd=self._auth.management_key,
         )
 
     def update_saml_application(
@@ -264,9 +261,9 @@ class SSOApplication(AuthBase):
         )
 
         uri = MgmtV1.sso_application_saml_update_path
-        self._auth.do_post(
+        self._http.post(
             uri,
-            SSOApplication._compose_create_update_saml_body(
+            body=SSOApplication._compose_create_update_saml_body(
                 name,
                 login_page_url,
                 id,
@@ -287,7 +284,6 @@ class SSOApplication(AuthBase):
                 force_authentication,
                 logout_redirect_url,
             ),
-            pswd=self._auth.management_key,
         )
 
     def delete(
@@ -304,7 +300,8 @@ class SSOApplication(AuthBase):
         AuthException: raised if deletion operation fails
         """
         uri = MgmtV1.sso_application_delete_path
-        self._auth.do_post(uri, {"id": id}, pswd=self._auth.management_key)
+        # Using adapter's do_post which already includes management key in Authorization header
+        self._http.post(uri, body={"id": id})
 
     def load(
         self,
@@ -324,11 +321,7 @@ class SSOApplication(AuthBase):
         Raise:
         AuthException: raised if load operation fails
         """
-        response = self._auth.do_get(
-            uri=MgmtV1.sso_application_load_path,
-            params={"id": id},
-            pswd=self._auth.management_key,
-        )
+        response = self._http.get(MgmtV1.sso_application_load_path, params={"id": id})
         return response.json()
 
     def load_all(
@@ -350,10 +343,7 @@ class SSOApplication(AuthBase):
         Raise:
         AuthException: raised if load operation fails
         """
-        response = self._auth.do_get(
-            uri=MgmtV1.sso_application_load_all_path,
-            pswd=self._auth.management_key,
-        )
+        response = self._http.get(MgmtV1.sso_application_load_all_path)
         return response.json()
 
     @staticmethod

--- a/descope/management/sso_settings.py
+++ b/descope/management/sso_settings.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from descope._auth_base import AuthBase
+from descope._http_base import HTTPBase
 from descope.management.common import MgmtV1
 
 
@@ -160,7 +160,7 @@ class SSOSAMLSettingsByMetadata:
         self.sp_entity_id = sp_entity_id
 
 
-class SSOSettings(AuthBase):
+class SSOSettings(HTTPBase):
     def load_settings(
         self,
         tenant_id: str,
@@ -179,10 +179,9 @@ class SSOSettings(AuthBase):
         Raise:
         AuthException: raised if load configuration operation fails
         """
-        response = self._auth.do_get(
+        response = self._http.get(
             uri=MgmtV1.sso_load_settings_path,
             params={"tenantId": tenant_id},
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -199,10 +198,9 @@ class SSOSettings(AuthBase):
         Raise:
         AuthException: raised if delete operation fails
         """
-        self._auth.do_delete(
+        self._http.delete(
             MgmtV1.sso_settings_path,
-            {"tenantId": tenant_id},
-            pswd=self._auth.management_key,
+            params={"tenantId": tenant_id},
         )
 
     def configure_oidc_settings(
@@ -223,12 +221,11 @@ class SSOSettings(AuthBase):
         AuthException: raised if configuration operation fails
         """
 
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.sso_configure_oidc_settings,
-            SSOSettings._compose_configure_oidc_settings_body(
+            body=SSOSettings._compose_configure_oidc_settings_body(
                 tenant_id, settings, domains
             ),
-            pswd=self._auth.management_key,
         )
 
     def configure_saml_settings(
@@ -251,12 +248,11 @@ class SSOSettings(AuthBase):
         AuthException: raised if configuration operation fails
         """
 
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.sso_configure_saml_settings,
-            SSOSettings._compose_configure_saml_settings_body(
+            body=SSOSettings._compose_configure_saml_settings_body(
                 tenant_id, settings, redirect_url, domains
             ),
-            pswd=self._auth.management_key,
         )
 
     def configure_saml_settings_by_metadata(
@@ -279,12 +275,11 @@ class SSOSettings(AuthBase):
         AuthException: raised if configuration operation fails
         """
 
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.sso_configure_saml_by_metadata_settings,
-            SSOSettings._compose_configure_saml_settings_by_metadata_body(
+            body=SSOSettings._compose_configure_saml_settings_by_metadata_body(
                 tenant_id, settings, redirect_url, domains
             ),
-            pswd=self._auth.management_key,
         )
 
     # DEPRECATED
@@ -306,10 +301,9 @@ class SSOSettings(AuthBase):
         Raise:
         AuthException: raised if configuration operation fails
         """
-        response = self._auth.do_get(
+        response = self._http.get(
             uri=MgmtV1.sso_settings_path,
             params={"tenantId": tenant_id},
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -339,12 +333,11 @@ class SSOSettings(AuthBase):
         Raise:
         AuthException: raised if configuration operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.sso_settings_path,
-            SSOSettings._compose_configure_body(
+            body=SSOSettings._compose_configure_body(
                 tenant_id, idp_url, entity_id, idp_cert, redirect_url, domains
             ),
-            pswd=self._auth.management_key,
         )
 
     # DEPRECATED
@@ -369,12 +362,11 @@ class SSOSettings(AuthBase):
         Raise:
         AuthException: raised if configuration operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.sso_metadata_path,
-            SSOSettings._compose_metadata_body(
+            body=SSOSettings._compose_metadata_body(
                 tenant_id, idp_metadata_url, redirect_url, domains
             ),
-            pswd=self._auth.management_key,
         )
 
     # DEPRECATED
@@ -397,12 +389,11 @@ class SSOSettings(AuthBase):
         Raise:
         AuthException: raised if configuration operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.sso_mapping_path,
-            SSOSettings._compose_mapping_body(
+            body=SSOSettings._compose_mapping_body(
                 tenant_id, role_mappings, attribute_mapping
             ),
-            pswd=self._auth.management_key,
         )
 
     @staticmethod

--- a/descope/management/tenant.py
+++ b/descope/management/tenant.py
@@ -1,10 +1,10 @@
 from typing import Any, List, Optional
 
-from descope._auth_base import AuthBase
+from descope._http_base import HTTPBase
 from descope.management.common import MgmtV1
 
 
-class Tenant(AuthBase):
+class Tenant(HTTPBase):
     def create(
         self,
         name: str,
@@ -38,10 +38,9 @@ class Tenant(AuthBase):
             [] if self_provisioning_domains is None else self_provisioning_domains
         )
 
-        uri = MgmtV1.tenant_create_path
-        response = self._auth.do_post(
-            uri,
-            Tenant._compose_create_update_body(
+        response = self._http.post(
+            MgmtV1.tenant_create_path,
+            body=Tenant._compose_create_update_body(
                 name,
                 id,
                 self_provisioning_domains,
@@ -49,7 +48,6 @@ class Tenant(AuthBase):
                 enforce_sso,
                 disabled,
             ),
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -82,10 +80,9 @@ class Tenant(AuthBase):
             [] if self_provisioning_domains is None else self_provisioning_domains
         )
 
-        uri = MgmtV1.tenant_update_path
-        self._auth.do_post(
-            uri,
-            Tenant._compose_create_update_body(
+        self._http.post(
+            MgmtV1.tenant_update_path,
+            body=Tenant._compose_create_update_body(
                 name,
                 id,
                 self_provisioning_domains,
@@ -93,7 +90,6 @@ class Tenant(AuthBase):
                 enforce_sso,
                 disabled,
             ),
-            pswd=self._auth.management_key,
         )
 
     def delete(
@@ -110,9 +106,9 @@ class Tenant(AuthBase):
         Raise:
         AuthException: raised if creation operation fails
         """
-        uri = MgmtV1.tenant_delete_path
-        self._auth.do_post(
-            uri, {"id": id, "cascade": cascade}, pswd=self._auth.management_key
+        self._http.post(
+            MgmtV1.tenant_delete_path,
+            body={"id": id, "cascade": cascade},
         )
 
     def load(
@@ -133,10 +129,9 @@ class Tenant(AuthBase):
         Raise:
         AuthException: raised if load operation fails
         """
-        response = self._auth.do_get(
-            uri=MgmtV1.tenant_load_path,
+        response = self._http.get(
+            MgmtV1.tenant_load_path,
             params={"id": id},
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -154,9 +149,8 @@ class Tenant(AuthBase):
         Raise:
         AuthException: raised if load operation fails
         """
-        response = self._auth.do_get(
-            uri=MgmtV1.tenant_load_all_path,
-            pswd=self._auth.management_key,
+        response = self._http.get(
+            MgmtV1.tenant_load_all_path,
         )
         return response.json()
 
@@ -184,15 +178,14 @@ class Tenant(AuthBase):
         Raise:
         AuthException: raised if load operation fails
         """
-        response = self._auth.do_post(
-            uri=MgmtV1.tenant_search_all_path,
+        response = self._http.post(
+            MgmtV1.tenant_search_all_path,
             body={
                 "tenantIds": ids,
                 "tenantNames": names,
                 "tenantSelfProvisioningDomains": self_provisioning_domains,
                 "customAttributes": custom_attributes,
             },
-            pswd=self._auth.management_key,
         )
         return response.json()
 

--- a/descope/management/user.py
+++ b/descope/management/user.py
@@ -1,8 +1,7 @@
 from typing import Any, List, Optional, Union
 
-from descope._auth_base import AuthBase
-from descope.auth import Auth
-from descope.common import DeliveryMethod, LoginOptions
+from descope._http_base import HTTPBase
+from descope.common import DeliveryMethod, LoginOptions, get_method_string
 from descope.exceptions import ERROR_TYPE_INVALID_ARGUMENT, AuthException
 from descope.management.common import (
     AssociatedTenant,
@@ -75,7 +74,7 @@ class CreateUserObj:
         self.family_name = family_name
 
 
-class User(AuthBase):
+class User(HTTPBase):
     def create(
         self,
         login_id: str,
@@ -122,9 +121,9 @@ class User(AuthBase):
         role_names = [] if role_names is None else role_names
         user_tenants = [] if user_tenants is None else user_tenants
 
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_create_path,
-            User._compose_create_body(
+            body=User._compose_create_body(
                 login_id,
                 email,
                 phone,
@@ -146,7 +145,6 @@ class User(AuthBase):
                 additional_login_ids,
                 sso_app_ids,
             ),
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -198,9 +196,9 @@ class User(AuthBase):
         role_names = [] if role_names is None else role_names
         user_tenants = [] if user_tenants is None else user_tenants
 
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.test_user_create_path,
-            User._compose_create_body(
+            body=User._compose_create_body(
                 login_id,
                 email,
                 phone,
@@ -222,7 +220,6 @@ class User(AuthBase):
                 additional_login_ids,
                 sso_app_ids,
             ),
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -267,9 +264,9 @@ class User(AuthBase):
         role_names = [] if role_names is None else role_names
         user_tenants = [] if user_tenants is None else user_tenants
 
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_create_path,
-            User._compose_create_body(
+            body=User._compose_create_body(
                 login_id,
                 email,
                 phone,
@@ -292,7 +289,6 @@ class User(AuthBase):
                 sso_app_ids,
                 template_id,
             ),
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -319,15 +315,14 @@ class User(AuthBase):
             calling the method.
         """
 
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_create_batch_path,
-            User._compose_create_batch_body(
+            body=User._compose_create_batch_body(
                 users,
                 invite_url,
                 send_mail,
                 send_sms,
             ),
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -383,9 +378,9 @@ class User(AuthBase):
         role_names = [] if role_names is None else role_names
         user_tenants = [] if user_tenants is None else user_tenants
 
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_update_path,
-            User._compose_update_body(
+            body=User._compose_update_body(
                 login_id,
                 email,
                 phone,
@@ -404,7 +399,6 @@ class User(AuthBase):
                 sso_app_ids,
                 None,
             ),
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -454,9 +448,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if patch operation fails
         """
-        response = self._auth.do_patch(
+        response = self._http.patch(
             MgmtV1.user_patch_path,
-            User._compose_patch_body(
+            body=User._compose_patch_body(
                 login_id,
                 email,
                 phone,
@@ -473,7 +467,6 @@ class User(AuthBase):
                 sso_app_ids,
                 test,
             ),
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -490,10 +483,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if delete operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.user_delete_path,
-            {"loginId": login_id},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id},
         )
 
     def delete_by_user_id(
@@ -509,10 +501,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if delete operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.user_delete_path,
-            {"userId": user_id},
-            pswd=self._auth.management_key,
+            body={"userId": user_id},
         )
 
     def delete_all_test_users(
@@ -524,9 +515,8 @@ class User(AuthBase):
         Raise:
         AuthException: raised if delete operation fails
         """
-        self._auth.do_delete(
+        self._http.delete(
             MgmtV1.user_delete_all_test_users_path,
-            pswd=self._auth.management_key,
         )
 
     def load(
@@ -547,10 +537,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if load operation fails
         """
-        response = self._auth.do_get(
+        response = self._http.get(
             uri=MgmtV1.user_load_path,
             params={"loginId": login_id},
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -573,10 +562,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if load operation fails
         """
-        response = self._auth.do_get(
+        response = self._http.get(
             uri=MgmtV1.user_load_path,
             params={"userId": user_id},
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -593,10 +581,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if logout operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.user_logout_path,
-            {"loginId": login_id},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id},
         )
 
     def logout_user_by_user_id(
@@ -612,10 +599,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if logout operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.user_logout_path,
-            {"userId": user_id},
-            pswd=self._auth.management_key,
+            body={"userId": user_id},
         )
 
     def search_all(
@@ -737,10 +723,9 @@ class User(AuthBase):
         if tenant_role_names is not None:
             body["tenantRoleNames"] = map_to_values_object(tenant_role_names)
 
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.users_search_path,
             body=body,
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -854,10 +839,9 @@ class User(AuthBase):
         if tenant_role_names is not None:
             body["tenantRoleNames"] = map_to_values_object(tenant_role_names)
 
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.test_users_search_path,
             body=body,
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -887,15 +871,14 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_get(
+        response = self._http.get(
             MgmtV1.user_get_provider_token,
-            {
+            params={
                 "loginId": login_id,
                 "provider": provider,
                 "withRefreshToken": withRefreshToken,
                 "forceRefresh": forceRefresh,
             },
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -917,10 +900,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if activate operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_update_status_path,
-            {"loginId": login_id, "status": "enabled"},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "status": "enabled"},
         )
         return response.json()
 
@@ -942,10 +924,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if deactivate operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_update_status_path,
-            {"loginId": login_id, "status": "disabled"},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "status": "disabled"},
         )
         return response.json()
 
@@ -970,10 +951,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the update operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_update_login_id_path,
-            {"loginId": login_id, "newLoginId": new_login_id},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "newLoginId": new_login_id},
         )
         return response.json()
 
@@ -999,10 +979,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the update operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_update_email_path,
-            {"loginId": login_id, "email": email, "verified": verified},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "email": email, "verified": verified},
         )
         return response.json()
 
@@ -1028,10 +1007,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the update operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_update_phone_path,
-            {"loginId": login_id, "phone": phone, "verified": verified},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "phone": phone, "verified": verified},
         )
         return response.json()
 
@@ -1067,10 +1045,9 @@ class User(AuthBase):
             bdy["middleName"] = middle_name
         if family_name is not None:
             bdy["familyName"] = family_name
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_update_name_path,
-            bdy,
-            pswd=self._auth.management_key,
+            body=bdy,
         )
         return response.json()
 
@@ -1094,10 +1071,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the update operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_update_picture_path,
-            {"loginId": login_id, "picture": picture},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "picture": picture},
         )
         return response.json()
 
@@ -1120,14 +1096,13 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the update operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_update_custom_attribute_path,
-            {
+            body={
                 "loginId": login_id,
                 "attributeKey": attribute_key,
                 "attributeValue": attribute_val,
             },
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -1152,10 +1127,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_set_role_path,
-            {"loginId": login_id, "roleNames": role_names},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "roleNames": role_names},
         )
         return response.json()
 
@@ -1180,10 +1154,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_add_role_path,
-            {"loginId": login_id, "roleNames": role_names},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "roleNames": role_names},
         )
         return response.json()
 
@@ -1208,10 +1181,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_remove_role_path,
-            {"loginId": login_id, "roleNames": role_names},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "roleNames": role_names},
         )
         return response.json()
 
@@ -1235,10 +1207,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_set_sso_apps,
-            {"loginId": login_id, "ssoAppIds": sso_app_ids},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "ssoAppIds": sso_app_ids},
         )
         return response.json()
 
@@ -1262,10 +1233,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_add_sso_apps,
-            {"loginId": login_id, "ssoAppIds": sso_app_ids},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "ssoAppIds": sso_app_ids},
         )
         return response.json()
 
@@ -1289,10 +1259,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_remove_sso_apps,
-            {"loginId": login_id, "ssoAppIds": sso_app_ids},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "ssoAppIds": sso_app_ids},
         )
         return response.json()
 
@@ -1316,10 +1285,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_add_tenant_path,
-            {"loginId": login_id, "tenantId": tenant_id},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "tenantId": tenant_id},
         )
         return response.json()
 
@@ -1343,10 +1311,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_remove_tenant_path,
-            {"loginId": login_id, "tenantId": tenant_id},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "tenantId": tenant_id},
         )
         return response.json()
 
@@ -1372,10 +1339,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_set_role_path,
-            {"loginId": login_id, "tenantId": tenant_id, "roleNames": role_names},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "tenantId": tenant_id, "roleNames": role_names},
         )
         return response.json()
 
@@ -1401,10 +1367,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_add_role_path,
-            {"loginId": login_id, "tenantId": tenant_id, "roleNames": role_names},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "tenantId": tenant_id, "roleNames": role_names},
         )
         return response.json()
 
@@ -1430,10 +1395,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_remove_role_path,
-            {"loginId": login_id, "tenantId": tenant_id, "roleNames": role_names},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id, "tenantId": tenant_id, "roleNames": role_names},
         )
         return response.json()
 
@@ -1455,14 +1419,13 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.user_set_temporary_password_path,
-            {
+            body={
                 "loginId": login_id,
                 "password": password,
                 "setActive": False,
             },
-            pswd=self._auth.management_key,
         )
         return
 
@@ -1481,14 +1444,13 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.user_set_active_password_path,
-            {
+            body={
                 "loginId": login_id,
                 "password": password,
                 "setActive": True,
             },
-            pswd=self._auth.management_key,
         )
         return
 
@@ -1513,14 +1475,13 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.user_set_password_path,
-            {
+            body={
                 "loginId": login_id,
                 "password": password,
                 "setActive": set_active,
             },
-            pswd=self._auth.management_key,
         )
         return
 
@@ -1539,10 +1500,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.user_expire_password_path,
-            {"loginId": login_id},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id},
         )
         return
 
@@ -1561,10 +1521,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.user_remove_all_passkeys_path,
-            {"loginId": login_id},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id},
         )
         return
 
@@ -1583,10 +1542,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        self._auth.do_post(
+        self._http.post(
             MgmtV1.user_remove_totp_seed_path,
-            {"loginId": login_id},
-            pswd=self._auth.management_key,
+            body={"loginId": login_id},
         )
         return
 
@@ -1614,14 +1572,13 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_generate_otp_for_test_path,
-            {
+            body={
                 "loginId": login_id,
-                "deliveryMethod": Auth.get_method_string(method),
+                "deliveryMethod": get_method_string(method),
                 "loginOptions": login_options.__dict__ if login_options else {},
             },
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -1651,15 +1608,14 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_generate_magic_link_for_test_path,
-            {
+            body={
                 "loginId": login_id,
-                "deliveryMethod": Auth.get_method_string(method),
+                "deliveryMethod": get_method_string(method),
                 "URI": uri,
                 "loginOptions": login_options.__dict__ if login_options else {},
             },
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -1686,14 +1642,13 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_generate_enchanted_link_for_test_path,
-            {
+            body={
                 "loginId": login_id,
                 "URI": uri,
                 "loginOptions": login_options.__dict__ if login_options else {},
             },
-            pswd=self._auth.management_key,
         )
         return response.json()
 
@@ -1714,10 +1669,13 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_generate_embedded_link_path,
-            {"loginId": login_id, "customClaims": custom_claims, "timeout": timeout},
-            pswd=self._auth.management_key,
+            body={
+                "loginId": login_id,
+                "customClaims": custom_claims,
+                "timeout": timeout,
+            },
         )
         return response.json()["token"]
 
@@ -1748,9 +1706,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_generate_sign_up_embedded_link_path,
-            {
+            body={
                 "loginId": login_id,
                 "user": user.__dict__ if user else {},
                 "loginOptions": login_options.__dict__ if login_options else {},
@@ -1758,7 +1716,6 @@ class User(AuthBase):
                 "phoneVerified": phone_verified,
                 "timeout": timeout,
             },
-            pswd=self._auth.management_key,
         )
         return response.json()["token"]
 
@@ -1784,10 +1741,9 @@ class User(AuthBase):
         Raise:
         AuthException: raised if the operation fails
         """
-        response = self._auth.do_post(
+        response = self._http.post(
             MgmtV1.user_history_path,
-            user_ids,
-            pswd=self._auth.management_key,
+            body=user_ids,
         )
         return response.json()
 

--- a/descope/mgmt.py
+++ b/descope/mgmt.py
@@ -1,129 +1,135 @@
-from descope.auth import Auth
-from descope.exceptions import ERROR_TYPE_INVALID_ARGUMENT, AuthException  # noqa: F401
-from descope.management.access_key import AccessKey  # noqa: F401
-from descope.management.audit import Audit  # noqa: F401
-from descope.management.authz import Authz  # noqa: F401
-from descope.management.fga import FGA  # noqa: F401
-from descope.management.flow import Flow  # noqa: F401
-from descope.management.group import Group  # noqa: F401
-from descope.management.jwt import JWT  # noqa: F401
-from descope.management.outbound_application import (  # noqa: F401  # noqa: F401
+from descope.exceptions import ERROR_TYPE_INVALID_ARGUMENT, AuthException
+from descope.http_client import HTTPClient
+from descope.management.access_key import AccessKey
+from descope.management.audit import Audit
+from descope.management.authz import Authz
+from descope.management.fga import FGA
+from descope.management.flow import Flow
+from descope.management.group import Group
+from descope.management.jwt import JWT
+from descope.management.outbound_application import (
     OutboundApplication,
     OutboundApplicationByToken,
 )
-from descope.management.permission import Permission  # noqa: F401
-from descope.management.project import Project  # noqa: F401
-from descope.management.role import Role  # noqa: F401
-from descope.management.sso_application import SSOApplication  # noqa: F401
-from descope.management.sso_settings import SSOSettings  # noqa: F401
-from descope.management.tenant import Tenant  # noqa: F401
+from descope.management.permission import Permission
+from descope.management.project import Project
+from descope.management.role import Role
+from descope.management.sso_application import SSOApplication
+from descope.management.sso_settings import SSOSettings
+
+# Import management modules after adapter to avoid circularities
+from descope.management.tenant import Tenant
 from descope.management.user import User
 
 
 class MGMT:
-    _auth: Auth
+    _http: HTTPClient
 
-    def __init__(self, auth: Auth):
-        self._auth = auth
-        self._tenant = Tenant(auth)
-        self._sso_application = SSOApplication(auth)
-        self._user = User(auth)
-        self._access_key = AccessKey(auth)
-        self._sso = SSOSettings(auth)
-        self._jwt = JWT(auth)
-        self._permission = Permission(auth)
-        self._role = Role(auth)
-        self._group = Group(auth)
-        self._flow = Flow(auth)
-        self._audit = Audit(auth)
-        self._authz = Authz(auth)
-        self._fga = FGA(auth)
-        self._project = Project(auth)
-        self._outbound_application = OutboundApplication(auth)
-        self._outbound_application_by_token = OutboundApplicationByToken(auth)
+    def __init__(self, http_client: HTTPClient):
+        """Create a management API facade.
 
-    def _check_management_key(self, property_name: str):
+        Args:
+            http_client: HTTP client to use for all management HTTP calls.
+        """
+        self._http = http_client
+        self._access_key = AccessKey(http_client)
+        self._audit = Audit(http_client)
+        self._authz = Authz(http_client)
+        self._fga = FGA(http_client)
+        self._flow = Flow(http_client)
+        self._group = Group(http_client)
+        self._jwt = JWT(http_client)
+        self._outbound_application = OutboundApplication(http_client)
+        self._outbound_application_by_token = OutboundApplicationByToken(http_client)
+        self._permission = Permission(http_client)
+        self._project = Project(http_client)
+        self._role = Role(http_client)
+        self._sso = SSOSettings(http_client)
+        self._sso_application = SSOApplication(http_client)
+        self._tenant = Tenant(http_client)
+        self._user = User(http_client)
+
+    def _ensure_management_key(self, property_name: str):
         """Check if management key is available for the given property."""
-        if not self._auth.management_key:
+        if not self._http.management_key:
             raise AuthException(
-                400,
-                ERROR_TYPE_INVALID_ARGUMENT,
-                f"Management key is required to access '{property_name}' functionality",
+                error_type=ERROR_TYPE_INVALID_ARGUMENT,
+                error_message=f"Management key is required to access '{property_name}' functionality",
             )
 
     @property
     def tenant(self):
-        self._check_management_key("tenant")
+        self._ensure_management_key("tenant")
         return self._tenant
 
     @property
     def sso_application(self):
-        self._check_management_key("sso_application")
+        self._ensure_management_key("sso_application")
         return self._sso_application
 
     @property
     def user(self):
-        self._check_management_key("user")
+        self._ensure_management_key("user")
         return self._user
 
     @property
     def access_key(self):
-        self._check_management_key("access_key")
+        self._ensure_management_key("access_key")
         return self._access_key
 
     @property
     def sso(self):
-        self._check_management_key("sso")
+        self._ensure_management_key("sso")
         return self._sso
 
     @property
     def jwt(self):
-        self._check_management_key("jwt")
+        self._ensure_management_key("jwt")
         return self._jwt
 
     @property
     def permission(self):
-        self._check_management_key("permission")
+        self._ensure_management_key("permission")
         return self._permission
 
     @property
     def role(self):
-        self._check_management_key("role")
+        self._ensure_management_key("role")
         return self._role
 
     @property
     def group(self):
-        self._check_management_key("group")
+        self._ensure_management_key("group")
         return self._group
 
     @property
     def flow(self):
-        self._check_management_key("flow")
+        self._ensure_management_key("flow")
         return self._flow
 
     @property
     def audit(self):
-        self._check_management_key("audit")
+        self._ensure_management_key("audit")
         return self._audit
 
     @property
     def authz(self):
-        self._check_management_key("authz")
+        self._ensure_management_key("authz")
         return self._authz
 
     @property
     def fga(self):
-        self._check_management_key("fga")
+        self._ensure_management_key("fga")
         return self._fga
 
     @property
     def project(self):
-        self._check_management_key("project")
+        self._ensure_management_key("project")
         return self._project
 
     @property
     def outbound_application(self):
-        self._check_management_key("outbound_application")
+        self._ensure_management_key("outbound_application")
         return self._outbound_application
 
     @property

--- a/tests/common.py
+++ b/tests/common.py
@@ -30,3 +30,29 @@ class DescopeTest(unittest.TestCase):
         os.environ["DESCOPE_BASE_URI"] = (
             DEFAULT_BASE_URL  # Make sure tests always running against localhost
         )
+        # Some tests instantiate Auth directly; provide defaults they can use
+        self.dummy_project_id = getattr(self, "dummy_project_id", "dummy")
+        self.public_key_dict = getattr(
+            self,
+            "public_key_dict",
+            {
+                "alg": "ES384",
+                "crv": "P-384",
+                "kid": "testkid",
+                "kty": "EC",
+                "use": "sig",
+                "x": "x",
+                "y": "y",
+            },
+        )
+
+    # Test helper to build a default HTTP client
+    def make_http_client(self, management_key: str | None = None):
+        from descope.http_client import HTTPClient
+
+        return HTTPClient(
+            project_id=self.dummy_project_id,
+            timeout_seconds=60,
+            secure=True,
+            management_key=management_key,
+        )

--- a/tests/management/test_jwt.py
+++ b/tests/management/test_jwt.py
@@ -9,7 +9,7 @@ from descope.management.common import MgmtLoginOptions, MgmtV1
 from .. import common
 
 
-class TestUser(common.DescopeTest):
+class TestJWT(common.DescopeTest):
     def setUp(self) -> None:
         super().setUp()
         self.dummy_project_id = "dummy"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,34 @@
+from enum import Enum
+
+from descope.common import DeliveryMethod, get_method_string
+from descope.exceptions import AuthException
+from tests import common
+
+
+class TestCommon(common.DescopeTest):
+    def test_get_method_string(self):
+        self.assertEqual(
+            get_method_string(DeliveryMethod.EMAIL),
+            "email",
+        )
+        self.assertEqual(
+            get_method_string(DeliveryMethod.SMS),
+            "sms",
+        )
+        self.assertEqual(
+            get_method_string(DeliveryMethod.VOICE),
+            "voice",
+        )
+        self.assertEqual(
+            get_method_string(DeliveryMethod.WHATSAPP),
+            "whatsapp",
+        )
+        self.assertEqual(
+            get_method_string(DeliveryMethod.EMBEDDED),
+            "Embedded",
+        )
+
+        class AAA(Enum):
+            DUMMY = 4
+
+        self.assertRaises(AuthException, get_method_string, AAA.DUMMY)

--- a/tests/test_enchantedlink.py
+++ b/tests/test_enchantedlink.py
@@ -96,7 +96,13 @@ class TestEnchantedLink(common.DescopeTest):
         )
 
     def test_sign_in(self):
-        enchantedlink = EnchantedLink(Auth(self.dummy_project_id, self.public_key_dict))
+        enchantedlink = EnchantedLink(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
         with patch("requests.post") as mock_post:
             my_mock_response = mock.Mock()
             my_mock_response.ok = True
@@ -198,7 +204,13 @@ class TestEnchantedLink(common.DescopeTest):
             )
 
     def test_sign_in_with_login_options(self):
-        enchantedlink = EnchantedLink(Auth(self.dummy_project_id, self.public_key_dict))
+        enchantedlink = EnchantedLink(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
         with patch("requests.post") as mock_post:
             my_mock_response = mock.Mock()
             my_mock_response.ok = True
@@ -230,7 +242,13 @@ class TestEnchantedLink(common.DescopeTest):
             )
 
     def test_sign_up(self):
-        enchantedlink = EnchantedLink(Auth(self.dummy_project_id, self.public_key_dict))
+        enchantedlink = EnchantedLink(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
         with patch("requests.post") as mock_post:
             my_mock_response = mock.Mock()
             my_mock_response.ok = True
@@ -343,7 +361,13 @@ class TestEnchantedLink(common.DescopeTest):
             self.assertEqual(res["pendingRef"], "aaaa")
 
     def test_sign_up_or_in(self):
-        enchantedlink = EnchantedLink(Auth(self.dummy_project_id, self.public_key_dict))
+        enchantedlink = EnchantedLink(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
         with patch("requests.post") as mock_post:
             my_mock_response = mock.Mock()
             my_mock_response.ok = True
@@ -410,7 +434,13 @@ class TestEnchantedLink(common.DescopeTest):
     def test_verify(self):
         token = "1234"
 
-        enchantedlink = EnchantedLink(Auth(self.dummy_project_id, self.public_key_dict))
+        enchantedlink = EnchantedLink(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         with patch("requests.post") as mock_post:
             mock_post.return_value.ok = False
@@ -434,7 +464,13 @@ class TestEnchantedLink(common.DescopeTest):
             self.assertIsNone(enchantedlink.verify(token))
 
     def test_get_session(self):
-        enchantedlink = EnchantedLink(Auth(self.dummy_project_id, self.public_key_dict))
+        enchantedlink = EnchantedLink(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         valid_jwt_token = "eyJhbGciOiJFUzM4NCIsImtpZCI6IlAyQ3R6VWhkcXBJRjJ5czlnZzdtczA2VXZ0QzQiLCJ0eXAiOiJKV1QifQ.eyJkcm4iOiJEU1IiLCJleHAiOjIyNjQ0Mzc1OTYsImlhdCI6MTY1OTYzNzU5NiwiaXNzIjoiUDJDdHpVaGRxcElGMnlzOWdnN21zMDZVdnRDNCIsInN1YiI6IlUyQ3UwajBXUHczWU9pUElTSmI1Mkwwd1VWTWcifQ.WLnlHugvzZtrV9OzBB7SjpCLNRvKF3ImFpVyIN5orkrjO2iyAKg_Rb4XHk9sXGC1aW8puYzLbhE1Jv3kk2hDcKggfE8OaRNRm8byhGFZHnvPJwcP_Ya-aRmfAvCLcKOL"
         with patch("requests.post") as mock_post:
@@ -449,7 +485,13 @@ class TestEnchantedLink(common.DescopeTest):
             self.assertIsNotNone(enchantedlink.get_session("aaaaaa"))
 
     def test_update_user_email(self):
-        enchantedlink = EnchantedLink(Auth(self.dummy_project_id, self.public_key_dict))
+        enchantedlink = EnchantedLink(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
         with patch("requests.post") as mock_post:
             my_mock_response = mock.Mock()
             my_mock_response.ok = True

--- a/tests/test_magiclink.py
+++ b/tests/test_magiclink.py
@@ -112,7 +112,13 @@ class TestMagicLink(common.DescopeTest):
         )
 
     def test_sign_in(self):
-        magiclink = MagicLink(Auth(self.dummy_project_id, self.public_key_dict))
+        magiclink = MagicLink(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(
@@ -231,7 +237,13 @@ class TestMagicLink(common.DescopeTest):
             "email": "dummy@dummy.com",
         }
 
-        magiclink = MagicLink(Auth(self.dummy_project_id, self.public_key_dict))
+        magiclink = MagicLink(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(
@@ -392,7 +404,13 @@ class TestMagicLink(common.DescopeTest):
             )
 
     def test_sign_up_or_in(self):
-        magiclink = MagicLink(Auth(self.dummy_project_id, self.public_key_dict))
+        magiclink = MagicLink(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
 
@@ -461,7 +479,13 @@ class TestMagicLink(common.DescopeTest):
     def test_verify(self):
         token = "1234"
 
-        magiclink = MagicLink(Auth(self.dummy_project_id, self.public_key_dict))
+        magiclink = MagicLink(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         with patch("requests.post") as mock_post:
             mock_post.return_value.ok = False
@@ -487,7 +511,7 @@ class TestMagicLink(common.DescopeTest):
     def test_verify_with_get_keys_mock(self):
         token = "1234"
         magiclink = MagicLink(
-            Auth(self.dummy_project_id, None)
+            Auth(self.dummy_project_id, None, http_client=self.make_http_client())
         )  # public key will be "fetched" by Get mock
 
         # Test success flow
@@ -508,7 +532,13 @@ class TestMagicLink(common.DescopeTest):
                 self.assertIsNotNone(magiclink.verify(token))
 
     def test_update_user_email(self):
-        magiclink = MagicLink(Auth(self.dummy_project_id, self.public_key_dict))
+        magiclink = MagicLink(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         self.assertRaises(
             AuthException,
@@ -593,7 +623,13 @@ class TestMagicLink(common.DescopeTest):
             )
 
     def test_update_user_phone(self):
-        magiclink = MagicLink(Auth(self.dummy_project_id, self.public_key_dict))
+        magiclink = MagicLink(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         self.assertRaises(
             AuthException,

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -43,7 +43,13 @@ class TestOAuth(common.DescopeTest):
         )
 
     def test_oauth_start(self):
-        oauth = OAuth(Auth(self.dummy_project_id, self.public_key_dict))
+        oauth = OAuth(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(AuthException, oauth.start, "")
@@ -84,7 +90,13 @@ class TestOAuth(common.DescopeTest):
             )
 
     def test_oauth_start_with_login_options(self):
-        oauth = OAuth(Auth(self.dummy_project_id, self.public_key_dict))
+        oauth = OAuth(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(AuthException, oauth.start, "")
@@ -121,7 +133,13 @@ class TestOAuth(common.DescopeTest):
         self.assertEqual(Auth._compose_exchange_body("c1"), {"code": "c1"})
 
     def test_exchange_token(self):
-        oauth = OAuth(Auth(self.dummy_project_id, self.public_key_dict))
+        oauth = OAuth(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(AuthException, oauth.exchange_token, "")

--- a/tests/test_password.py
+++ b/tests/test_password.py
@@ -32,7 +32,13 @@ class TestPassword(common.DescopeTest):
             "email": "dummy@dummy.com",
         }
 
-        password = Password(Auth(self.dummy_project_id, self.public_key_dict))
+        password = Password(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(
@@ -117,7 +123,13 @@ class TestPassword(common.DescopeTest):
             )
 
     def test_sign_in(self):
-        password = Password(Auth(self.dummy_project_id, self.public_key_dict))
+        password = Password(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(
@@ -189,7 +201,13 @@ class TestPassword(common.DescopeTest):
             )
 
     def test_send_reset(self):
-        password = Password(Auth(self.dummy_project_id, self.public_key_dict))
+        password = Password(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(
@@ -284,7 +302,13 @@ class TestPassword(common.DescopeTest):
             )
 
     def test_update(self):
-        password = Password(Auth(self.dummy_project_id, self.public_key_dict))
+        password = Password(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(
@@ -370,7 +394,13 @@ class TestPassword(common.DescopeTest):
             )
 
     def test_replace(self):
-        password = Password(Auth(self.dummy_project_id, self.public_key_dict))
+        password = Password(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(
@@ -466,7 +496,13 @@ class TestPassword(common.DescopeTest):
             )
 
     def test_policy(self):
-        password = Password(Auth(self.dummy_project_id, self.public_key_dict))
+        password = Password(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         with patch("requests.get") as mock_get:
             mock_get.return_value.ok = False

--- a/tests/test_saml.py
+++ b/tests/test_saml.py
@@ -32,7 +32,13 @@ class TestSAML(common.DescopeTest):
         )
 
     def test_saml_start(self):
-        saml = SAML(Auth(self.dummy_project_id, self.public_key_dict))
+        saml = SAML(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(AuthException, saml.start, "", "http://dummy.com")
@@ -77,7 +83,13 @@ class TestSAML(common.DescopeTest):
             )
 
     def test_saml_start_with_login_options(self):
-        saml = SAML(Auth(self.dummy_project_id, self.public_key_dict))
+        saml = SAML(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(AuthException, saml.start, "", "http://dummy.com")
@@ -119,7 +131,13 @@ class TestSAML(common.DescopeTest):
         self.assertEqual(Auth._compose_exchange_body("c1"), {"code": "c1"})
 
     def test_exchange_token(self):
-        saml = SAML(Auth(self.dummy_project_id, self.public_key_dict))
+        saml = SAML(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(AuthException, saml.exchange_token, "")

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -42,7 +42,13 @@ class TestSSO(common.DescopeTest):
         )
 
     def test_sso_start(self):
-        sso = SSO(Auth(self.dummy_project_id, self.public_key_dict))
+        sso = SSO(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(AuthException, sso.start, "", "http://dummy.com")
@@ -87,7 +93,13 @@ class TestSSO(common.DescopeTest):
             )
 
     def test_sso_start_with_login_options(self):
-        sso = SSO(Auth(self.dummy_project_id, self.public_key_dict))
+        sso = SSO(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(AuthException, sso.start, "", "http://dummy.com")
@@ -125,7 +137,13 @@ class TestSSO(common.DescopeTest):
         self.assertEqual(Auth._compose_exchange_body("c1"), {"code": "c1"})
 
     def test_exchange_token(self):
-        sso = SSO(Auth(self.dummy_project_id, self.public_key_dict))
+        sso = SSO(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(AuthException, sso.exchange_token, "")

--- a/tests/test_totp.py
+++ b/tests/test_totp.py
@@ -32,7 +32,13 @@ class TestTOTP(common.DescopeTest):
             "email": "dummy@dummy.com",
         }
 
-        totp = TOTP(Auth(self.dummy_project_id, self.public_key_dict))
+        totp = TOTP(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(
@@ -64,7 +70,13 @@ class TestTOTP(common.DescopeTest):
             self.assertIsNotNone(totp.sign_up("dummy@dummy.com", signup_user_details))
 
     def test_sign_in(self):
-        totp = TOTP(Auth(self.dummy_project_id, self.public_key_dict))
+        totp = TOTP(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(AuthException, totp.sign_in_code, None, "1234")
@@ -137,7 +149,13 @@ class TestTOTP(common.DescopeTest):
             )
 
     def test_update_user(self):
-        totp = TOTP(Auth(self.dummy_project_id, self.public_key_dict))
+        totp = TOTP(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(AuthException, totp.update_user, None, "")

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -80,7 +80,13 @@ class TestWebauthN(common.DescopeTest):
         )
 
     def test_sign_up_start(self):
-        webauthn = WebAuthn(Auth(self.dummy_project_id, self.public_key_dict))
+        webauthn = WebAuthn(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(
@@ -126,7 +132,13 @@ class TestWebauthN(common.DescopeTest):
             self.assertEqual(res, valid_response)
 
     def test_sign_up_finish(self):
-        webauthn = WebAuthn(Auth(self.dummy_project_id, self.public_key_dict))
+        webauthn = WebAuthn(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(AuthException, webauthn.sign_up_finish, "", "response01")
@@ -176,7 +188,13 @@ class TestWebauthN(common.DescopeTest):
             self.assertIsNotNone(webauthn.sign_up_finish("t01", "response01"))
 
     def test_sign_in_start(self):
-        webauthn = WebAuthn(Auth(self.dummy_project_id, self.public_key_dict))
+        webauthn = WebAuthn(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(
@@ -237,7 +255,13 @@ class TestWebauthN(common.DescopeTest):
             self.assertEqual(res, valid_response)
 
     def test_sign_in_start_with_login_options(self):
-        webauthn = WebAuthn(Auth(self.dummy_project_id, self.public_key_dict))
+        webauthn = WebAuthn(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(
@@ -296,7 +320,13 @@ class TestWebauthN(common.DescopeTest):
             self.assertEqual(res, valid_response)
 
     def test_sign_in_finish(self):
-        webauthn = WebAuthn(Auth(self.dummy_project_id, self.public_key_dict))
+        webauthn = WebAuthn(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(AuthException, webauthn.sign_in_finish, "", "response01")
@@ -340,7 +370,13 @@ class TestWebauthN(common.DescopeTest):
             self.assertIsNotNone(webauthn.sign_up_finish("t01", "response01"))
 
     def test_sign_up_or_in_start(self):
-        webauthn = WebAuthn(Auth(self.dummy_project_id, self.public_key_dict))
+        webauthn = WebAuthn(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(
@@ -394,7 +430,13 @@ class TestWebauthN(common.DescopeTest):
 
     def test_update_start(self):
         valid_jwt_token = "eyJhbGciOiJFUzM4NCIsImtpZCI6IjJCdDVXTGNjTFVleTFEcDd1dHB0WmIzRng5SyIsInR5cCI6IkpXVCJ9.eyJhdXRob3JpemVkVGVuYW50cyI6eyIiOm51bGx9LCJjb29raWVEb21haW4iOiIiLCJjb29raWVFeHBpcmF0aW9uIjoxNjYwNjc5MjA4LCJjb29raWVNYXhBZ2UiOjI1OTE5OTksImNvb2tpZU5hbWUiOiJEU1IiLCJjb29raWVQYXRoIjoiLyIsImV4cCI6MjA5MDA4NzIwOCwiaWF0IjoxNjU4MDg3MjA4LCJpc3MiOiIyQnQ1V0xjY0xVZXkxRHA3dXRwdFpiM0Z4OUsiLCJzdWIiOiIyQzU1dnl4dzBzUkw2RmRNNjhxUnNDRGRST1YifQ.cWP5up4R5xeIl2qoG2NtfLH3Q5nRJVKdz-FDoAXctOQW9g3ceZQi6rZQ-TPBaXMKw68bijN3bLJTqxWW5WHzqRUeopfuzTcMYmC0wP2XGJkrdF6A8D5QW6acSGqglFgu"
-        webauthn = WebAuthn(Auth(self.dummy_project_id, self.public_key_dict))
+        webauthn = WebAuthn(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(
@@ -463,7 +505,13 @@ class TestWebauthN(common.DescopeTest):
             self.assertEqual(res, valid_response)
 
     def test_update_finish(self):
-        webauthn = WebAuthn(Auth(self.dummy_project_id, self.public_key_dict))
+        webauthn = WebAuthn(
+            Auth(
+                self.dummy_project_id,
+                self.public_key_dict,
+                http_client=self.make_http_client(),
+            )
+        )
 
         # Test failed flows
         self.assertRaises(AuthException, webauthn.update_finish, "", "response01")


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/8683

## Description

Introduce HTTPClient to encapsulate the different mgmt keys needs, and use it to perform requests instead of having the HTTP methods implemented directly under the Auth class.

## Must

- [x] Tests
- [ ] Documentation (if applicable)
