### PR TITLE
Adjust jwt expiry error messages

### DIFF
--- a/descope/auth.py
+++ b/descope/auth.py
@@ -637,11 +637,17 @@ class Auth:
                 audience=audience,
                 leeway=self.jwt_validation_leeway,
             )
-        except (ImmatureSignatureError, ExpiredSignatureError):
+        except (ImmatureSignatureError):
             raise AuthException(
                 400,
                 ERROR_TYPE_INVALID_TOKEN,
-                "Received Invalid token times error due to time glitch (between machines) during jwt validation, try to set the jwt_validation_leeway parameter (in DescopeClient) to higher value than 5sec which is the default",
+                "Received Invalid token (nbf in future) during jwt validation. Error can be due to time glitch (between machines), try to set the jwt_validation_leeway parameter (in DescopeClient) to higher value than 5sec which is the default",
+            )
+        except (ExpiredSignatureError):
+            raise AuthException(
+                401,
+                ERROR_TYPE_INVALID_TOKEN,
+                "Received expired token (exp in past) during jwt validation. (sometimes can be due to time glitch (between machines), try to set the jwt_validation_leeway parameter (in DescopeClient) to higher value than 5sec which is the default)",
             )
 
         claims["jwt"] = token

--- a/tests/test_descope_client.py
+++ b/tests/test_descope_client.py
@@ -824,7 +824,7 @@ class TestDescopeClient(common.DescopeTest):
         self.assertEqual(cm.exception.status_code, 400)
         self.assertEqual(
             cm.exception.error_message,
-            "Received Invalid token times error due to time glitch (between machines) during jwt validation, try to set the jwt_validation_leeway parameter (in DescopeClient) to higher value than 5sec which is the default",
+            "Received Invalid token (nbf in future) during jwt validation. Error can be due to time glitch (between machines), try to set the jwt_validation_leeway parameter (in DescopeClient) to higher value than 5sec which is the default",
         )
 
     def test_select_tenant(self):


### PR DESCRIPTION
Just split the exceptions handling for returning clearer error messages