### PR TITLE
Create outbound application by DCR Preset

### DIFF
--- a/descope/management/common.py
+++ b/descope/management/common.py
@@ -49,6 +49,7 @@ class MgmtV1:
 
     # outbound application
     outbound_application_create_path = "/v1/mgmt/outbound/app/create"
+    outbound_application_create_by_dcr_preset_path = "/v1/mgmt/outbound/app/create/bydcrpreset"
     outbound_application_update_path = "/v1/mgmt/outbound/app/update"
     outbound_application_delete_path = "/v1/mgmt/outbound/app/delete"
     outbound_application_load_path = "/v1/mgmt/outbound/app"

--- a/descope/management/outbound_application.py
+++ b/descope/management/outbound_application.py
@@ -188,6 +188,31 @@ class OutboundApplication(AuthBase):
         )
         return response.json()
 
+    def create_application_by_dcr_preset(
+        self,
+        dcr_preset_id: str,
+    ) -> dict:
+        """
+        Create a new outbound application using a DCR (Dynamic Client Registration) preset.
+
+        Args:
+        dcr_preset_id (str): The ID of the DCR preset to use for creating the application.
+
+        Return value (dict):
+        Return dict in the format
+             {"app": {"id": <id>, "name": <name>, "description": <description>, "logo": <logo>}}
+
+        Raise:
+        AuthException: raised if create operation fails
+        """
+        uri = MgmtV1.outbound_application_create_by_dcr_preset_path
+        response = self._auth.do_post(
+            uri,
+            {"dcrPresetId": dcr_preset_id},
+            pswd=self._auth.management_key,
+        )
+        return response.json()
+
     def update_application(
         self,
         id: str,

--- a/tests/management/test_outbound_application.py
+++ b/tests/management/test_outbound_application.py
@@ -126,6 +126,53 @@ class TestOutboundApplication(common.DescopeTest):
                 "Test App",
             )
 
+    def test_create_application_by_dcr_preset_success(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        with patch("requests.post") as mock_post:
+            network_resp = mock.Mock()
+            network_resp.ok = True
+            network_resp.json.return_value = {
+                "app": {
+                    "id": "app123",
+                    "name": "DCR Preset App",
+                    "description": "App created from DCR preset",
+                }
+            }
+            mock_post.return_value = network_resp
+            response = client.mgmt.outbound_application.create_application_by_dcr_preset(
+                "dcr-preset-456"
+            )
+
+            assert response == {
+                "app": {
+                    "id": "app123",
+                    "name": "DCR Preset App",
+                    "description": "App created from DCR preset",
+                }
+            }
+
+    def test_create_application_by_dcr_preset_failure(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.ok = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.outbound_application.create_application_by_dcr_preset,
+                "dcr-preset-456",
+            )
+
     def test_update_application_success(self):
         client = DescopeClient(
             self.dummy_project_id,


### PR DESCRIPTION
## Related Issues
* https://github.com/descope/etc/issues/10611

## Description

Add the ability to create outbound application according to existing dcr preset

## Must

- [x] Tests
- [ ] Documentation (if applicable)
