### PR TITLE
feat: populate jwt_response.claims

### DIFF
--- a/descope/auth.py
+++ b/descope/auth.py
@@ -562,6 +562,7 @@ class Auth:
 
         jwt_response["user"] = response_body.get("user", {})
         jwt_response["firstSeen"] = response_body.get("firstSeen", True)
+        jwt_response["claims"] = response_body.get("claims", {})
         return jwt_response
 
     def _get_default_headers(self, pswd: str | None = None):


### PR DESCRIPTION
## Related Issues

Part-of: https://github.com/descope/etc/issues/11910

Honestly this feels extraneous with the adjacent `sessionToken` being a dict with the claims in a non-cookie environment, but it doesn't hurt to be consistent across SDKs.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
