### PR TITLE
feat(roles-permissions): add id-based management methods and role_ids search

### DIFF
--- a/descope/management/permission.py
+++ b/descope/management/permission.py
@@ -108,6 +108,29 @@ class Permission(HTTPBase):
             body={"name": name, "newName": new_name, "description": description},
         )
 
+    def update_with_id(
+        self,
+        id: str,
+        new_name: str,
+        description: Optional[str] = None,
+    ):
+        """
+        Update an existing permission identified by its ID. IMPORTANT: All parameters are used as overrides
+        to the existing permission. Empty fields will override populated fields. Use carefully.
+
+        Args:
+        id (str): permission ID (e.g. PERM...).
+        new_name (str): permission updated name.
+        description (str): Optional description to briefly explain what this permission allows.
+
+        Raise:
+        AuthException: raised if update operation fails
+        """
+        self._http.post(
+            MgmtV1.permission_update_path,
+            body={"id": id, "newName": new_name, "description": description},
+        )
+
     def delete(
         self,
         name: str,
@@ -124,6 +147,24 @@ class Permission(HTTPBase):
         self._http.post(
             MgmtV1.permission_delete_path,
             body={"name": name},
+        )
+
+    def delete_with_id(
+        self,
+        id: str,
+    ):
+        """
+        Delete an existing permission by its ID. IMPORTANT: This action is irreversible. Use carefully.
+
+        Args:
+        id (str): The ID of the permission to be deleted (e.g. PERM...).
+
+        Raise:
+        AuthException: raised if deletion operation fails
+        """
+        self._http.post(
+            MgmtV1.permission_delete_path,
+            body={"id": id},
         )
 
     def load_all(

--- a/descope/management/permission.py
+++ b/descope/management/permission.py
@@ -54,7 +54,7 @@ class Permission(HTTPBase):
 
         Args:
         permissions (List[dict]): List of permission objects, each with:
-            - name (str): current permission name.
+            - name (str): current permission name (or id (str): permission ID, e.g. PERM...).
             - newName (str): new permission name.
             - description (str): Optional new description.
 

--- a/descope/management/permission.py
+++ b/descope/management/permission.py
@@ -54,7 +54,7 @@ class Permission(HTTPBase):
 
         Args:
         permissions (List[dict]): List of permission objects, each with:
-            - name (str): current permission name (or id: permission ID).
+            - name (str): current permission name.
             - newName (str): new permission name.
             - description (str): Optional new description.
 
@@ -68,88 +68,122 @@ class Permission(HTTPBase):
 
     def delete_batch(
         self,
-        names: Optional[List[str]] = None,
-        *,
-        ids: Optional[List[str]] = None,
+        names: List[str],
     ):
         """
         Delete a batch of permissions in a single atomic transaction.
         IMPORTANT: This action is irreversible. Use carefully.
 
         Args:
-        names (List[str]): Optional list of permission names to delete.
-        ids (List[str]): Optional list of permission IDs to delete (e.g. PERM...).
+        names (List[str]): List of permission names to delete.
 
         Raise:
         AuthException: raised if deletion operation fails
         """
-        body: dict = {}
-        if names is not None:
-            body["names"] = names
-        if ids:
-            body["ids"] = ids
         self._http.post(
             MgmtV1.permission_delete_batch_path,
-            body=body,
+            body={"names": names},
+        )
+
+    def delete_batch_by_ids(
+        self,
+        ids: List[str],
+    ):
+        """
+        Delete a batch of permissions by their IDs in a single atomic transaction.
+        IMPORTANT: This action is irreversible. Use carefully.
+
+        Args:
+        ids (List[str]): List of permission IDs to delete (e.g. PERM...).
+
+        Raise:
+        AuthException: raised if deletion operation fails
+        """
+        self._http.post(
+            MgmtV1.permission_delete_batch_path,
+            body={"ids": ids},
         )
 
     def update(
         self,
-        name: Optional[str] = None,
-        new_name: str = "",
+        name: str,
+        new_name: str,
         description: Optional[str] = None,
-        *,
-        id: Optional[str] = None,
     ):
         """
-        Update an existing permission. Identify by name or ID (exactly one required).
-        IMPORTANT: All parameters are used as overrides to the existing permission.
-        Empty fields will override populated fields. Use carefully.
+        Update an existing permission with the given various fields. IMPORTANT: All parameters are used as overrides
+        to the existing permission. Empty fields will override populated fields. Use carefully.
 
         Args:
-        name (str): current permission name (mutually exclusive with id).
+        name (str): permission name.
         new_name (str): permission updated name.
         description (str): Optional description to briefly explain what this permission allows.
-        id (str): permission ID, e.g. PERM... (mutually exclusive with name).
 
         Raise:
         AuthException: raised if update operation fails
         """
-        body: dict = {"newName": new_name, "description": description}
-        if id is not None:
-            body["id"] = id
-        else:
-            body["name"] = name
         self._http.post(
             MgmtV1.permission_update_path,
-            body=body,
+            body={"name": name, "newName": new_name, "description": description},
+        )
+
+    def update_by_id(
+        self,
+        id: str,
+        new_name: str,
+        description: Optional[str] = None,
+    ):
+        """
+        Update an existing permission identified by its ID. IMPORTANT: All parameters are used as overrides
+        to the existing permission. Empty fields will override populated fields. Use carefully.
+
+        Args:
+        id (str): permission ID (e.g. PERM...).
+        new_name (str): permission updated name.
+        description (str): Optional description to briefly explain what this permission allows.
+
+        Raise:
+        AuthException: raised if update operation fails
+        """
+        self._http.post(
+            MgmtV1.permission_update_path,
+            body={"id": id, "newName": new_name, "description": description},
         )
 
     def delete(
         self,
-        name: Optional[str] = None,
-        *,
-        id: Optional[str] = None,
+        name: str,
     ):
         """
-        Delete an existing permission. Identify by name or ID (exactly one required).
-        IMPORTANT: This action is irreversible. Use carefully.
+        Delete an existing permission. IMPORTANT: This action is irreversible. Use carefully.
 
         Args:
-        name (str): The name of the permission to be deleted (mutually exclusive with id).
-        id (str): The ID of the permission to be deleted, e.g. PERM... (mutually exclusive with name).
+        name (str): The name of the permission to be deleted.
+
+        Raise:
+        AuthException: raised if creation operation fails
+        """
+        self._http.post(
+            MgmtV1.permission_delete_path,
+            body={"name": name},
+        )
+
+    def delete_by_id(
+        self,
+        id: str,
+    ):
+        """
+        Delete an existing permission by its ID. IMPORTANT: This action is irreversible. Use carefully.
+
+        Args:
+        id (str): The ID of the permission to be deleted (e.g. PERM...).
 
         Raise:
         AuthException: raised if deletion operation fails
         """
-        body: dict = {}
-        if id is not None:
-            body["id"] = id
-        else:
-            body["name"] = name
         self._http.post(
             MgmtV1.permission_delete_path,
-            body=body,
+            body={"id": id},
         )
 
     def load_all(

--- a/descope/management/permission.py
+++ b/descope/management/permission.py
@@ -54,7 +54,7 @@ class Permission(HTTPBase):
 
         Args:
         permissions (List[dict]): List of permission objects, each with:
-            - name (str): current permission name.
+            - name (str): current permission name (or id: permission ID).
             - newName (str): new permission name.
             - description (str): Optional new description.
 
@@ -68,103 +68,88 @@ class Permission(HTTPBase):
 
     def delete_batch(
         self,
-        names: List[str],
+        names: Optional[List[str]] = None,
+        *,
+        ids: Optional[List[str]] = None,
     ):
         """
         Delete a batch of permissions in a single atomic transaction.
         IMPORTANT: This action is irreversible. Use carefully.
 
         Args:
-        names (List[str]): List of permission names to delete.
+        names (List[str]): Optional list of permission names to delete.
+        ids (List[str]): Optional list of permission IDs to delete (e.g. PERM...).
 
         Raise:
         AuthException: raised if deletion operation fails
         """
+        body = {}
+        if names:
+            body["names"] = names
+        if ids:
+            body["ids"] = ids
         self._http.post(
             MgmtV1.permission_delete_batch_path,
-            body={"names": names},
+            body=body,
         )
 
     def update(
         self,
-        name: str,
-        new_name: str,
+        name: Optional[str] = None,
+        new_name: str = "",
         description: Optional[str] = None,
+        *,
+        id: Optional[str] = None,
     ):
         """
-        Update an existing permission with the given various fields. IMPORTANT: All parameters are used as overrides
-        to the existing permission. Empty fields will override populated fields. Use carefully.
+        Update an existing permission. Identify by name or ID (exactly one required).
+        IMPORTANT: All parameters are used as overrides to the existing permission.
+        Empty fields will override populated fields. Use carefully.
 
         Args:
-        name (str): permission name.
+        name (str): current permission name (mutually exclusive with id).
         new_name (str): permission updated name.
         description (str): Optional description to briefly explain what this permission allows.
+        id (str): permission ID, e.g. PERM... (mutually exclusive with name).
 
         Raise:
         AuthException: raised if update operation fails
         """
+        body: dict = {"newName": new_name, "description": description}
+        if id is not None:
+            body["id"] = id
+        else:
+            body["name"] = name
         self._http.post(
             MgmtV1.permission_update_path,
-            body={"name": name, "newName": new_name, "description": description},
-        )
-
-    def update_with_id(
-        self,
-        id: str,
-        new_name: str,
-        description: Optional[str] = None,
-    ):
-        """
-        Update an existing permission identified by its ID. IMPORTANT: All parameters are used as overrides
-        to the existing permission. Empty fields will override populated fields. Use carefully.
-
-        Args:
-        id (str): permission ID (e.g. PERM...).
-        new_name (str): permission updated name.
-        description (str): Optional description to briefly explain what this permission allows.
-
-        Raise:
-        AuthException: raised if update operation fails
-        """
-        self._http.post(
-            MgmtV1.permission_update_path,
-            body={"id": id, "newName": new_name, "description": description},
+            body=body,
         )
 
     def delete(
         self,
-        name: str,
+        name: Optional[str] = None,
+        *,
+        id: Optional[str] = None,
     ):
         """
-        Delete an existing permission. IMPORTANT: This action is irreversible. Use carefully.
+        Delete an existing permission. Identify by name or ID (exactly one required).
+        IMPORTANT: This action is irreversible. Use carefully.
 
         Args:
-        name (str): The name of the permission to be deleted.
-
-        Raise:
-        AuthException: raised if creation operation fails
-        """
-        self._http.post(
-            MgmtV1.permission_delete_path,
-            body={"name": name},
-        )
-
-    def delete_with_id(
-        self,
-        id: str,
-    ):
-        """
-        Delete an existing permission by its ID. IMPORTANT: This action is irreversible. Use carefully.
-
-        Args:
-        id (str): The ID of the permission to be deleted (e.g. PERM...).
+        name (str): The name of the permission to be deleted (mutually exclusive with id).
+        id (str): The ID of the permission to be deleted, e.g. PERM... (mutually exclusive with name).
 
         Raise:
         AuthException: raised if deletion operation fails
         """
+        body: dict = {}
+        if id is not None:
+            body["id"] = id
+        else:
+            body["name"] = name
         self._http.post(
             MgmtV1.permission_delete_path,
-            body={"id": id},
+            body=body,
         )
 
     def load_all(

--- a/descope/management/permission.py
+++ b/descope/management/permission.py
@@ -83,8 +83,8 @@ class Permission(HTTPBase):
         Raise:
         AuthException: raised if deletion operation fails
         """
-        body = {}
-        if names:
+        body: dict = {}
+        if names is not None:
             body["names"] = names
         if ids:
             body["ids"] = ids

--- a/descope/management/role.py
+++ b/descope/management/role.py
@@ -77,7 +77,7 @@ class Role(HTTPBase):
 
         Args:
         roles (List[dict]): List of role objects, each with:
-            - name (str): current role name.
+            - name (str): current role name (or id: role ID).
             - newName (str): new role name.
             - description (str): Optional new description.
             - permissionNames (List[str]): Optional list of permission names.
@@ -95,142 +95,112 @@ class Role(HTTPBase):
 
     def delete_batch(
         self,
-        roles: List[dict],
+        role_names: Optional[List[str]] = None,
+        tenant_id: Optional[str] = None,
+        *,
+        role_ids: Optional[List[str]] = None,
     ):
         """
         Delete a batch of roles in a single atomic transaction.
         IMPORTANT: This action is irreversible. Use carefully.
 
         Args:
-        roles (List[dict]): List of role objects to delete, each with:
-            - name (str): role name.
-            - tenantId (str): Optional tenant ID.
+        role_names (List[str]): Optional list of role names to delete.
+        tenant_id (str): Optional tenant ID the roles belong to.
+        role_ids (List[str]): Optional list of role IDs to delete (e.g. ROL...).
 
         Raise:
         AuthException: raised if deletion operation fails
         """
+        body: dict = {}
+        if role_names:
+            body["roleNames"] = role_names
+        if tenant_id is not None:
+            body["tenantId"] = tenant_id
+        if role_ids:
+            body["roleIds"] = role_ids
         self._http.post(
             MgmtV1.role_delete_batch_path,
-            body={"roles": roles},
+            body=body,
         )
 
     def update(
         self,
-        name: str,
-        new_name: str,
+        name: Optional[str] = None,
+        new_name: str = "",
         description: Optional[str] = None,
         permission_names: Optional[List[str]] = None,
         tenant_id: Optional[str] = None,
         default: Optional[bool] = None,
         private: Optional[bool] = None,
+        *,
+        id: Optional[str] = None,
     ):
         """
-        Update an existing role with the given various fields. IMPORTANT: All parameters are used as overrides
-        to the existing role. Empty fields will override populated fields. Use carefully.
+        Update an existing role. Identify by name or ID (exactly one required).
+        IMPORTANT: All parameters are used as overrides to the existing role.
+        Empty fields will override populated fields. Use carefully.
 
         Args:
-        name (str): role name.
+        name (str): current role name (mutually exclusive with id).
         new_name (str): role updated name.
         description (str): Optional description to briefly explain what this role allows.
         permission_names (List[str]): Optional list of names of permissions this role grants.
         tenant_id (str): Optional tenant ID to update the role in.
         default (bool): Optional marks this role as default role.
         private (bool): Optional marks this role as private role.
+        id (str): role ID, e.g. ROL... (mutually exclusive with name).
 
         Raise:
         AuthException: raised if update operation fails
         """
         permission_names = [] if permission_names is None else permission_names
+        body: dict = {
+            "newName": new_name,
+            "description": description,
+            "permissionNames": permission_names,
+            "tenantId": tenant_id,
+            "default": default,
+            "private": private,
+        }
+        if id is not None:
+            body["id"] = id
+        else:
+            body["name"] = name
         self._http.post(
             MgmtV1.role_update_path,
-            body={
-                "name": name,
-                "newName": new_name,
-                "description": description,
-                "permissionNames": permission_names,
-                "tenantId": tenant_id,
-                "default": default,
-                "private": private,
-            },
-        )
-
-    def update_with_id(
-        self,
-        id: str,
-        new_name: str,
-        description: Optional[str] = None,
-        permission_names: Optional[List[str]] = None,
-        tenant_id: Optional[str] = None,
-        default: Optional[bool] = None,
-        private: Optional[bool] = None,
-    ):
-        """
-        Update an existing role identified by its ID. IMPORTANT: All parameters are used as overrides
-        to the existing role. Empty fields will override populated fields. Use carefully.
-
-        Args:
-        id (str): role ID (e.g. ROL...).
-        new_name (str): role updated name.
-        description (str): Optional description to briefly explain what this role allows.
-        permission_names (List[str]): Optional list of names of permissions this role grants.
-        tenant_id (str): Optional tenant ID to update the role in.
-        default (bool): Optional marks this role as default role.
-        private (bool): Optional marks this role as private role.
-
-        Raise:
-        AuthException: raised if update operation fails
-        """
-        permission_names = [] if permission_names is None else permission_names
-        self._http.post(
-            MgmtV1.role_update_path,
-            body={
-                "id": id,
-                "newName": new_name,
-                "description": description,
-                "permissionNames": permission_names,
-                "tenantId": tenant_id,
-                "default": default,
-                "private": private,
-            },
+            body=body,
         )
 
     def delete(
         self,
-        name: str,
+        name: Optional[str] = None,
         tenant_id: Optional[str] = None,
+        *,
+        id: Optional[str] = None,
     ):
         """
-        Delete an existing role. IMPORTANT: This action is irreversible. Use carefully.
+        Delete an existing role. Identify by name or ID (exactly one required).
+        IMPORTANT: This action is irreversible. Use carefully.
 
         Args:
-        name (str): The name of the role to be deleted.
-
-        Raise:
-        AuthException: raised if creation operation fails
-        """
-        self._http.post(
-            MgmtV1.role_delete_path,
-            body={"name": name, "tenantId": tenant_id},
-        )
-
-    def delete_with_id(
-        self,
-        id: str,
-        tenant_id: Optional[str] = None,
-    ):
-        """
-        Delete an existing role by its ID. IMPORTANT: This action is irreversible. Use carefully.
-
-        Args:
-        id (str): The ID of the role to be deleted (e.g. ROL...).
+        name (str): The name of the role to be deleted (mutually exclusive with id).
         tenant_id (str): Optional tenant ID the role belongs to.
+        id (str): The ID of the role to be deleted, e.g. ROL... (mutually exclusive with name).
 
         Raise:
         AuthException: raised if deletion operation fails
         """
+        body: dict = {}
+        if id is not None:
+            body["id"] = id
+        else:
+            body["name"] = name
+        if tenant_id is not None:
+            body["tenantId"] = tenant_id
         self._http.post(
             MgmtV1.role_delete_path,
-            body={"id": id, "tenantId": tenant_id},
+            body=body,
         )
 
     def load_all(

--- a/descope/management/role.py
+++ b/descope/management/role.py
@@ -154,6 +154,46 @@ class Role(HTTPBase):
             },
         )
 
+    def update_with_id(
+        self,
+        id: str,
+        new_name: str,
+        description: Optional[str] = None,
+        permission_names: Optional[List[str]] = None,
+        tenant_id: Optional[str] = None,
+        default: Optional[bool] = None,
+        private: Optional[bool] = None,
+    ):
+        """
+        Update an existing role identified by its ID. IMPORTANT: All parameters are used as overrides
+        to the existing role. Empty fields will override populated fields. Use carefully.
+
+        Args:
+        id (str): role ID (e.g. ROL...).
+        new_name (str): role updated name.
+        description (str): Optional description to briefly explain what this role allows.
+        permission_names (List[str]): Optional list of names of permissions this role grants.
+        tenant_id (str): Optional tenant ID to update the role in.
+        default (bool): Optional marks this role as default role.
+        private (bool): Optional marks this role as private role.
+
+        Raise:
+        AuthException: raised if update operation fails
+        """
+        permission_names = [] if permission_names is None else permission_names
+        self._http.post(
+            MgmtV1.role_update_path,
+            body={
+                "id": id,
+                "newName": new_name,
+                "description": description,
+                "permissionNames": permission_names,
+                "tenantId": tenant_id,
+                "default": default,
+                "private": private,
+            },
+        )
+
     def delete(
         self,
         name: str,
@@ -171,6 +211,26 @@ class Role(HTTPBase):
         self._http.post(
             MgmtV1.role_delete_path,
             body={"name": name, "tenantId": tenant_id},
+        )
+
+    def delete_with_id(
+        self,
+        id: str,
+        tenant_id: Optional[str] = None,
+    ):
+        """
+        Delete an existing role by its ID. IMPORTANT: This action is irreversible. Use carefully.
+
+        Args:
+        id (str): The ID of the role to be deleted (e.g. ROL...).
+        tenant_id (str): Optional tenant ID the role belongs to.
+
+        Raise:
+        AuthException: raised if deletion operation fails
+        """
+        self._http.post(
+            MgmtV1.role_delete_path,
+            body={"id": id, "tenantId": tenant_id},
         )
 
     def load_all(
@@ -199,6 +259,7 @@ class Role(HTTPBase):
         role_name_like: Optional[str] = None,
         permission_names: Optional[List[str]] = None,
         include_project_roles: Optional[bool] = None,
+        role_ids: Optional[List[str]] = None,
     ) -> dict:
         """
         Search roles based on the given filters.
@@ -208,10 +269,11 @@ class Role(HTTPBase):
         role_names (List[str]): Only return matching roles to the given names
         role_name_like (str): Return roles that contain the given string ignoring case
         permission_names (List[str]): Only return roles that have the given permissions
+        role_ids (List[str]): Only return roles matching the given IDs (e.g. ROL...)
 
         Return value (dict):
         Return dict in the format
-             {"roles": [{"name": <name>, "description": <description>, "permissionNames":[]}] }
+             {"roles": [{"id": <id>, "name": <name>, "description": <description>, "permissionNames":[]}] }
         Containing the loaded role information.
 
         Raise:
@@ -228,6 +290,8 @@ class Role(HTTPBase):
             body["permissionNames"] = permission_names
         if include_project_roles is not None:
             body["includeProjectRoles"] = include_project_roles
+        if role_ids is not None:
+            body["roleIds"] = role_ids
 
         response = self._http.post(
             MgmtV1.role_search_path,

--- a/descope/management/role.py
+++ b/descope/management/role.py
@@ -95,8 +95,7 @@ class Role(HTTPBase):
 
     def delete_batch(
         self,
-        role_names: Optional[List[str]] = None,
-        tenant_id: Optional[str] = None,
+        roles: Optional[List[dict]] = None,
         *,
         role_ids: Optional[List[str]] = None,
     ):
@@ -105,18 +104,22 @@ class Role(HTTPBase):
         IMPORTANT: This action is irreversible. Use carefully.
 
         Args:
-        role_names (List[str]): Optional list of role names to delete.
-        tenant_id (str): Optional tenant ID the roles belong to.
+        roles (List[dict]): List of role objects to delete, each with:
+            - name (str): role name.
+            - tenantId (str): Optional tenant ID.
         role_ids (List[str]): Optional list of role IDs to delete (e.g. ROL...).
 
         Raise:
         AuthException: raised if deletion operation fails
         """
         body: dict = {}
-        if role_names:
-            body["roleNames"] = role_names
-        if tenant_id is not None:
-            body["tenantId"] = tenant_id
+        if roles:
+            names = [r["name"] for r in roles if r.get("name")]
+            if names:
+                body["roleNames"] = names
+            tenant_id = next((r.get("tenantId") for r in roles if r.get("tenantId")), None)
+            if tenant_id:
+                body["tenantId"] = tenant_id
         if role_ids:
             body["roleIds"] = role_ids
         self._http.post(
@@ -191,13 +194,11 @@ class Role(HTTPBase):
         Raise:
         AuthException: raised if deletion operation fails
         """
-        body: dict = {}
+        body: dict = {"tenantId": tenant_id}
         if id is not None:
             body["id"] = id
         else:
             body["name"] = name
-        if tenant_id is not None:
-            body["tenantId"] = tenant_id
         self._http.post(
             MgmtV1.role_delete_path,
             body=body,

--- a/descope/management/role.py
+++ b/descope/management/role.py
@@ -77,7 +77,7 @@ class Role(HTTPBase):
 
         Args:
         roles (List[dict]): List of role objects, each with:
-            - name (str): current role name (or id: role ID).
+            - name (str): current role name.
             - newName (str): new role name.
             - description (str): Optional new description.
             - permissionNames (List[str]): Optional list of permission names.
@@ -95,9 +95,7 @@ class Role(HTTPBase):
 
     def delete_batch(
         self,
-        roles: Optional[List[dict]] = None,
-        *,
-        role_ids: Optional[List[str]] = None,
+        roles: List[dict],
     ):
         """
         Delete a batch of roles in a single atomic transaction.
@@ -107,101 +105,153 @@ class Role(HTTPBase):
         roles (List[dict]): List of role objects to delete, each with:
             - name (str): role name.
             - tenantId (str): Optional tenant ID.
-        role_ids (List[str]): Optional list of role IDs to delete (e.g. ROL...).
 
         Raise:
         AuthException: raised if deletion operation fails
         """
-        body: dict = {}
-        if roles:
-            names = [r["name"] for r in roles if r.get("name")]
-            if names:
-                body["roleNames"] = names
-            tenant_id = next((r.get("tenantId") for r in roles if r.get("tenantId")), None)
-            if tenant_id:
-                body["tenantId"] = tenant_id
-        if role_ids:
-            body["roleIds"] = role_ids
         self._http.post(
             MgmtV1.role_delete_batch_path,
-            body=body,
+            body={"roles": roles},
+        )
+
+    def delete_batch_by_ids(
+        self,
+        role_ids: List[str],
+        tenant_id: Optional[str] = None,
+    ):
+        """
+        Delete a batch of roles by their IDs in a single atomic transaction.
+        IMPORTANT: This action is irreversible. Use carefully.
+
+        Args:
+        role_ids (List[str]): List of role IDs to delete (e.g. ROL...).
+        tenant_id (str): Optional tenant ID the roles belong to.
+
+        Raise:
+        AuthException: raised if deletion operation fails
+        """
+        self._http.post(
+            MgmtV1.role_delete_batch_path,
+            body={"roleIds": role_ids, "tenantId": tenant_id},
         )
 
     def update(
         self,
-        name: Optional[str] = None,
-        new_name: str = "",
+        name: str,
+        new_name: str,
         description: Optional[str] = None,
         permission_names: Optional[List[str]] = None,
         tenant_id: Optional[str] = None,
         default: Optional[bool] = None,
         private: Optional[bool] = None,
-        *,
-        id: Optional[str] = None,
     ):
         """
-        Update an existing role. Identify by name or ID (exactly one required).
-        IMPORTANT: All parameters are used as overrides to the existing role.
-        Empty fields will override populated fields. Use carefully.
+        Update an existing role with the given various fields. IMPORTANT: All parameters are used as overrides
+        to the existing role. Empty fields will override populated fields. Use carefully.
 
         Args:
-        name (str): current role name (mutually exclusive with id).
+        name (str): role name.
         new_name (str): role updated name.
         description (str): Optional description to briefly explain what this role allows.
         permission_names (List[str]): Optional list of names of permissions this role grants.
         tenant_id (str): Optional tenant ID to update the role in.
         default (bool): Optional marks this role as default role.
         private (bool): Optional marks this role as private role.
-        id (str): role ID, e.g. ROL... (mutually exclusive with name).
 
         Raise:
         AuthException: raised if update operation fails
         """
         permission_names = [] if permission_names is None else permission_names
-        body: dict = {
-            "newName": new_name,
-            "description": description,
-            "permissionNames": permission_names,
-            "tenantId": tenant_id,
-            "default": default,
-            "private": private,
-        }
-        if id is not None:
-            body["id"] = id
-        else:
-            body["name"] = name
         self._http.post(
             MgmtV1.role_update_path,
-            body=body,
+            body={
+                "name": name,
+                "newName": new_name,
+                "description": description,
+                "permissionNames": permission_names,
+                "tenantId": tenant_id,
+                "default": default,
+                "private": private,
+            },
+        )
+
+    def update_by_id(
+        self,
+        id: str,
+        new_name: str,
+        description: Optional[str] = None,
+        permission_names: Optional[List[str]] = None,
+        tenant_id: Optional[str] = None,
+        default: Optional[bool] = None,
+        private: Optional[bool] = None,
+    ):
+        """
+        Update an existing role identified by its ID. IMPORTANT: All parameters are used as overrides
+        to the existing role. Empty fields will override populated fields. Use carefully.
+
+        Args:
+        id (str): role ID (e.g. ROL...).
+        new_name (str): role updated name.
+        description (str): Optional description to briefly explain what this role allows.
+        permission_names (List[str]): Optional list of names of permissions this role grants.
+        tenant_id (str): Optional tenant ID to update the role in.
+        default (bool): Optional marks this role as default role.
+        private (bool): Optional marks this role as private role.
+
+        Raise:
+        AuthException: raised if update operation fails
+        """
+        permission_names = [] if permission_names is None else permission_names
+        self._http.post(
+            MgmtV1.role_update_path,
+            body={
+                "id": id,
+                "newName": new_name,
+                "description": description,
+                "permissionNames": permission_names,
+                "tenantId": tenant_id,
+                "default": default,
+                "private": private,
+            },
         )
 
     def delete(
         self,
-        name: Optional[str] = None,
+        name: str,
         tenant_id: Optional[str] = None,
-        *,
-        id: Optional[str] = None,
     ):
         """
-        Delete an existing role. Identify by name or ID (exactly one required).
-        IMPORTANT: This action is irreversible. Use carefully.
+        Delete an existing role. IMPORTANT: This action is irreversible. Use carefully.
 
         Args:
-        name (str): The name of the role to be deleted (mutually exclusive with id).
+        name (str): The name of the role to be deleted.
+
+        Raise:
+        AuthException: raised if creation operation fails
+        """
+        self._http.post(
+            MgmtV1.role_delete_path,
+            body={"name": name, "tenantId": tenant_id},
+        )
+
+    def delete_by_id(
+        self,
+        id: str,
+        tenant_id: Optional[str] = None,
+    ):
+        """
+        Delete an existing role by its ID. IMPORTANT: This action is irreversible. Use carefully.
+
+        Args:
+        id (str): The ID of the role to be deleted (e.g. ROL...).
         tenant_id (str): Optional tenant ID the role belongs to.
-        id (str): The ID of the role to be deleted, e.g. ROL... (mutually exclusive with name).
 
         Raise:
         AuthException: raised if deletion operation fails
         """
-        body: dict = {"tenantId": tenant_id}
-        if id is not None:
-            body["id"] = id
-        else:
-            body["name"] = name
         self._http.post(
             MgmtV1.role_delete_path,
-            body=body,
+            body={"id": id, "tenantId": tenant_id},
         )
 
     def load_all(

--- a/descope/management/role.py
+++ b/descope/management/role.py
@@ -77,7 +77,7 @@ class Role(HTTPBase):
 
         Args:
         roles (List[dict]): List of role objects, each with:
-            - name (str): current role name.
+            - name (str): current role name (or id (str): role ID, e.g. ROL...).
             - newName (str): new role name.
             - description (str): Optional new description.
             - permissionNames (List[str]): Optional list of permission names.

--- a/tests/management/test_permission.py
+++ b/tests/management/test_permission.py
@@ -287,7 +287,7 @@ class TestPermission(common.DescopeTest):
                 [{"name": "P1", "newName": "P1-new"}],
             )
 
-        # Test success flow
+        # Test success flow — by name
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
             self.assertIsNone(
@@ -310,6 +310,36 @@ class TestPermission(common.DescopeTest):
                     "permissions": [
                         {"name": "P1", "newName": "P1-new", "description": "d1"},
                         {"name": "P2", "newName": "P2-new"},
+                    ]
+                },
+                follow_redirects=False,
+                verify=SSLMatcher(),
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+
+        # Test success flow — by id
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = True
+            self.assertIsNone(
+                client.mgmt.permission.update_batch(
+                    [
+                        {"id": "PERM1", "newName": "P1-new", "description": "d1"},
+                        {"id": "PERM2", "newName": "P2-new"},
+                    ]
+                )
+            )
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.permission_update_batch_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                    "x-descope-project-id": self.dummy_project_id,
+                },
+                params=None,
+                json={
+                    "permissions": [
+                        {"id": "PERM1", "newName": "P1-new", "description": "d1"},
+                        {"id": "PERM2", "newName": "P2-new"},
                     ]
                 },
                 follow_redirects=False,

--- a/tests/management/test_permission.py
+++ b/tests/management/test_permission.py
@@ -146,6 +146,83 @@ class TestPermission(common.DescopeTest):
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
 
+    def test_update_with_id(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flow
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.permission.update_with_id,
+                "PERM123",
+                "new-name",
+            )
+
+        # Test success flow
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = True
+            self.assertIsNone(
+                client.mgmt.permission.update_with_id("PERM123", "new-name", "new-description")
+            )
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.permission_update_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                    "x-descope-project-id": self.dummy_project_id,
+                },
+                params=None,
+                json={
+                    "id": "PERM123",
+                    "newName": "new-name",
+                    "description": "new-description",
+                },
+                follow_redirects=False,
+                verify=SSLMatcher(),
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+
+    def test_delete_with_id(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flow
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.permission.delete_with_id,
+                "PERM123",
+            )
+
+        # Test success flow
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = True
+            self.assertIsNone(client.mgmt.permission.delete_with_id("PERM123"))
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.permission_delete_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                    "x-descope-project-id": self.dummy_project_id,
+                },
+                params=None,
+                json={"id": "PERM123"},
+                follow_redirects=False,
+                verify=SSLMatcher(),
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+
     def test_create_batch(self):
         client = DescopeClient(
             self.dummy_project_id,

--- a/tests/management/test_permission.py
+++ b/tests/management/test_permission.py
@@ -159,16 +159,16 @@ class TestPermission(common.DescopeTest):
             mock_post.return_value.is_success = False
             self.assertRaises(
                 AuthException,
-                client.mgmt.permission.update_with_id,
-                "PERM123",
-                "new-name",
+                client.mgmt.permission.update,
+                id="PERM123",
+                new_name="new-name",
             )
 
         # Test success flow
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
             self.assertIsNone(
-                client.mgmt.permission.update_with_id("PERM123", "new-name", "new-description")
+                client.mgmt.permission.update(new_name="new-name", description="new-description", id="PERM123")
             )
             mock_post.assert_called_with(
                 f"{common.DEFAULT_BASE_URL}{MgmtV1.permission_update_path}",
@@ -201,14 +201,14 @@ class TestPermission(common.DescopeTest):
             mock_post.return_value.is_success = False
             self.assertRaises(
                 AuthException,
-                client.mgmt.permission.delete_with_id,
-                "PERM123",
+                client.mgmt.permission.delete,
+                id="PERM123",
             )
 
         # Test success flow
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
-            self.assertIsNone(client.mgmt.permission.delete_with_id("PERM123"))
+            self.assertIsNone(client.mgmt.permission.delete(id="PERM123"))
             mock_post.assert_called_with(
                 f"{common.DEFAULT_BASE_URL}{MgmtV1.permission_delete_path}",
                 headers={
@@ -347,6 +347,31 @@ class TestPermission(common.DescopeTest):
                 },
                 params=None,
                 json={"names": ["P1", "P2"]},
+                follow_redirects=False,
+                verify=SSLMatcher(),
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+
+    def test_delete_batch_by_ids(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = True
+            self.assertIsNone(client.mgmt.permission.delete_batch(ids=["PERM1", "PERM2"]))
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.permission_delete_batch_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                    "x-descope-project-id": self.dummy_project_id,
+                },
+                params=None,
+                json={"ids": ["PERM1", "PERM2"]},
                 follow_redirects=False,
                 verify=SSLMatcher(),
                 timeout=DEFAULT_TIMEOUT_SECONDS,

--- a/tests/management/test_permission.py
+++ b/tests/management/test_permission.py
@@ -109,6 +109,48 @@ class TestPermission(common.DescopeTest):
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
 
+    def test_update_by_id(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flow
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.permission.update_by_id,
+                "PERM123",
+                "new-name",
+            )
+
+        # Test success flow
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = True
+            self.assertIsNone(
+                client.mgmt.permission.update_by_id("PERM123", "new-name", "new-description")
+            )
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.permission_update_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                    "x-descope-project-id": self.dummy_project_id,
+                },
+                params=None,
+                json={
+                    "id": "PERM123",
+                    "newName": "new-name",
+                    "description": "new-description",
+                },
+                follow_redirects=False,
+                verify=SSLMatcher(),
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+
     def test_delete(self):
         client = DescopeClient(
             self.dummy_project_id,
@@ -146,7 +188,7 @@ class TestPermission(common.DescopeTest):
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
 
-    def test_update_with_id(self):
+    def test_delete_by_id(self):
         client = DescopeClient(
             self.dummy_project_id,
             self.public_key_dict,
@@ -159,56 +201,14 @@ class TestPermission(common.DescopeTest):
             mock_post.return_value.is_success = False
             self.assertRaises(
                 AuthException,
-                client.mgmt.permission.update,
-                id="PERM123",
-                new_name="new-name",
+                client.mgmt.permission.delete_by_id,
+                "PERM123",
             )
 
         # Test success flow
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
-            self.assertIsNone(
-                client.mgmt.permission.update(new_name="new-name", description="new-description", id="PERM123")
-            )
-            mock_post.assert_called_with(
-                f"{common.DEFAULT_BASE_URL}{MgmtV1.permission_update_path}",
-                headers={
-                    **common.default_headers,
-                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
-                    "x-descope-project-id": self.dummy_project_id,
-                },
-                params=None,
-                json={
-                    "id": "PERM123",
-                    "newName": "new-name",
-                    "description": "new-description",
-                },
-                follow_redirects=False,
-                verify=SSLMatcher(),
-                timeout=DEFAULT_TIMEOUT_SECONDS,
-            )
-
-    def test_delete_with_id(self):
-        client = DescopeClient(
-            self.dummy_project_id,
-            self.public_key_dict,
-            False,
-            self.dummy_management_key,
-        )
-
-        # Test failed flow
-        with patch("httpx.post") as mock_post:
-            mock_post.return_value.is_success = False
-            self.assertRaises(
-                AuthException,
-                client.mgmt.permission.delete,
-                id="PERM123",
-            )
-
-        # Test success flow
-        with patch("httpx.post") as mock_post:
-            mock_post.return_value.is_success = True
-            self.assertIsNone(client.mgmt.permission.delete(id="PERM123"))
+            self.assertIsNone(client.mgmt.permission.delete_by_id("PERM123"))
             mock_post.assert_called_with(
                 f"{common.DEFAULT_BASE_URL}{MgmtV1.permission_delete_path}",
                 headers={
@@ -360,9 +360,19 @@ class TestPermission(common.DescopeTest):
             self.dummy_management_key,
         )
 
+        # Test failed flow
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.permission.delete_batch_by_ids,
+                ["PERM1"],
+            )
+
+        # Test success flow
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
-            self.assertIsNone(client.mgmt.permission.delete_batch(ids=["PERM1", "PERM2"]))
+            self.assertIsNone(client.mgmt.permission.delete_batch_by_ids(["PERM1", "PERM2"]))
             mock_post.assert_called_with(
                 f"{common.DEFAULT_BASE_URL}{MgmtV1.permission_delete_batch_path}",
                 headers={

--- a/tests/management/test_role.py
+++ b/tests/management/test_role.py
@@ -147,7 +147,7 @@ class TestRole(common.DescopeTest):
                 [{"name": "R1", "newName": "R1-new"}],
             )
 
-        # Test success flow
+        # Test success flow — by name
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
             self.assertIsNone(
@@ -186,6 +186,36 @@ class TestRole(common.DescopeTest):
                             "private": True,
                         },
                         {"name": "R2", "newName": "R2-new"},
+                    ]
+                },
+                follow_redirects=False,
+                verify=SSLMatcher(),
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+
+        # Test success flow — by id
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = True
+            self.assertIsNone(
+                client.mgmt.role.update_batch(
+                    [
+                        {"id": "ROL1", "newName": "R1-new", "description": "d1"},
+                        {"id": "ROL2", "newName": "R2-new"},
+                    ]
+                )
+            )
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.role_update_batch_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                    "x-descope-project-id": self.dummy_project_id,
+                },
+                params=None,
+                json={
+                    "roles": [
+                        {"id": "ROL1", "newName": "R1-new", "description": "d1"},
+                        {"id": "ROL2", "newName": "R2-new"},
                     ]
                 },
                 follow_redirects=False,

--- a/tests/management/test_role.py
+++ b/tests/management/test_role.py
@@ -276,7 +276,7 @@ class TestRole(common.DescopeTest):
                     "x-descope-project-id": self.dummy_project_id,
                 },
                 params=None,
-                json={"name": "name"},
+                json={"name": "name", "tenantId": None},
                 follow_redirects=False,
                 verify=SSLMatcher(),
                 timeout=DEFAULT_TIMEOUT_SECONDS,
@@ -379,20 +379,23 @@ class TestRole(common.DescopeTest):
             self.dummy_management_key,
         )
 
-        # Test failed flow (by names)
+        # Test failed flow (by names, original call style)
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = False
             self.assertRaises(
                 AuthException,
                 client.mgmt.role.delete_batch,
-                ["R1"],
+                [{"name": "R1"}],
             )
 
-        # Test success flow — by names with tenantId
+        # Test success flow — by names with tenantId (original call style)
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
             self.assertIsNone(
-                client.mgmt.role.delete_batch(["R1", "R2"], "t1")
+                client.mgmt.role.delete_batch([
+                    {"name": "R1", "tenantId": "t1"},
+                    {"name": "R2"},
+                ])
             )
             mock_post.assert_called_with(
                 f"{common.DEFAULT_BASE_URL}{MgmtV1.role_delete_batch_path}",
@@ -408,7 +411,7 @@ class TestRole(common.DescopeTest):
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
 
-        # Test success flow — by IDs
+        # Test success flow — by IDs (new kwarg)
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
             self.assertIsNone(

--- a/tests/management/test_role.py
+++ b/tests/management/test_role.py
@@ -276,7 +276,7 @@ class TestRole(common.DescopeTest):
                     "x-descope-project-id": self.dummy_project_id,
                 },
                 params=None,
-                json={"name": "name", "tenantId": None},
+                json={"name": "name"},
                 follow_redirects=False,
                 verify=SSLMatcher(),
                 timeout=DEFAULT_TIMEOUT_SECONDS,
@@ -295,23 +295,23 @@ class TestRole(common.DescopeTest):
             mock_post.return_value.is_success = False
             self.assertRaises(
                 AuthException,
-                client.mgmt.role.update_with_id,
-                "ROL123",
-                "new-name",
+                client.mgmt.role.update,
+                id="ROL123",
+                new_name="new-name",
             )
 
         # Test success flow
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
             self.assertIsNone(
-                client.mgmt.role.update_with_id(
-                    "ROL123",
-                    "new-name",
-                    "new-description",
-                    ["P1", "P2"],
-                    "t1",
-                    True,
-                    False,
+                client.mgmt.role.update(
+                    new_name="new-name",
+                    description="new-description",
+                    permission_names=["P1", "P2"],
+                    tenant_id="t1",
+                    default=True,
+                    private=False,
+                    id="ROL123",
                 )
             )
             mock_post.assert_called_with(
@@ -349,14 +349,14 @@ class TestRole(common.DescopeTest):
             mock_post.return_value.is_success = False
             self.assertRaises(
                 AuthException,
-                client.mgmt.role.delete_with_id,
-                "ROL123",
+                client.mgmt.role.delete,
+                id="ROL123",
             )
 
         # Test success flow
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
-            self.assertIsNone(client.mgmt.role.delete_with_id("ROL123", "t1"))
+            self.assertIsNone(client.mgmt.role.delete(tenant_id="t1", id="ROL123"))
             mock_post.assert_called_with(
                 f"{common.DEFAULT_BASE_URL}{MgmtV1.role_delete_path}",
                 headers={
@@ -379,25 +379,20 @@ class TestRole(common.DescopeTest):
             self.dummy_management_key,
         )
 
-        # Test failed flow
+        # Test failed flow (by names)
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = False
             self.assertRaises(
                 AuthException,
                 client.mgmt.role.delete_batch,
-                [{"name": "R1"}],
+                ["R1"],
             )
 
-        # Test success flow
+        # Test success flow — by names with tenantId
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
             self.assertIsNone(
-                client.mgmt.role.delete_batch(
-                    [
-                        {"name": "R1", "tenantId": "t1"},
-                        {"name": "R2"},
-                    ]
-                )
+                client.mgmt.role.delete_batch(["R1", "R2"], "t1")
             )
             mock_post.assert_called_with(
                 f"{common.DEFAULT_BASE_URL}{MgmtV1.role_delete_batch_path}",
@@ -407,12 +402,27 @@ class TestRole(common.DescopeTest):
                     "x-descope-project-id": self.dummy_project_id,
                 },
                 params=None,
-                json={
-                    "roles": [
-                        {"name": "R1", "tenantId": "t1"},
-                        {"name": "R2"},
-                    ]
+                json={"roleNames": ["R1", "R2"], "tenantId": "t1"},
+                follow_redirects=False,
+                verify=SSLMatcher(),
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+
+        # Test success flow — by IDs
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = True
+            self.assertIsNone(
+                client.mgmt.role.delete_batch(role_ids=["ROL1", "ROL2"])
+            )
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.role_delete_batch_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                    "x-descope-project-id": self.dummy_project_id,
                 },
+                params=None,
+                json={"roleIds": ["ROL1", "ROL2"]},
                 follow_redirects=False,
                 verify=SSLMatcher(),
                 timeout=DEFAULT_TIMEOUT_SECONDS,

--- a/tests/management/test_role.py
+++ b/tests/management/test_role.py
@@ -247,6 +247,60 @@ class TestRole(common.DescopeTest):
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
 
+    def test_update_by_id(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flow
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.role.update_by_id,
+                "ROL123",
+                "new-name",
+            )
+
+        # Test success flow
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = True
+            self.assertIsNone(
+                client.mgmt.role.update_by_id(
+                    "ROL123",
+                    "new-name",
+                    "new-description",
+                    ["P1", "P2"],
+                    "t1",
+                    True,
+                    False,
+                )
+            )
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.role_update_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                    "x-descope-project-id": self.dummy_project_id,
+                },
+                params=None,
+                json={
+                    "id": "ROL123",
+                    "newName": "new-name",
+                    "description": "new-description",
+                    "permissionNames": ["P1", "P2"],
+                    "tenantId": "t1",
+                    "default": True,
+                    "private": False,
+                },
+                follow_redirects=False,
+                verify=SSLMatcher(),
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+
     def test_delete(self):
         client = DescopeClient(
             self.dummy_project_id,
@@ -282,7 +336,7 @@ class TestRole(common.DescopeTest):
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
 
-    def test_update_with_id(self):
+    def test_delete_by_id(self):
         client = DescopeClient(
             self.dummy_project_id,
             self.public_key_dict,
@@ -295,68 +349,14 @@ class TestRole(common.DescopeTest):
             mock_post.return_value.is_success = False
             self.assertRaises(
                 AuthException,
-                client.mgmt.role.update,
-                id="ROL123",
-                new_name="new-name",
+                client.mgmt.role.delete_by_id,
+                "ROL123",
             )
 
         # Test success flow
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
-            self.assertIsNone(
-                client.mgmt.role.update(
-                    new_name="new-name",
-                    description="new-description",
-                    permission_names=["P1", "P2"],
-                    tenant_id="t1",
-                    default=True,
-                    private=False,
-                    id="ROL123",
-                )
-            )
-            mock_post.assert_called_with(
-                f"{common.DEFAULT_BASE_URL}{MgmtV1.role_update_path}",
-                headers={
-                    **common.default_headers,
-                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
-                    "x-descope-project-id": self.dummy_project_id,
-                },
-                params=None,
-                json={
-                    "id": "ROL123",
-                    "newName": "new-name",
-                    "description": "new-description",
-                    "permissionNames": ["P1", "P2"],
-                    "tenantId": "t1",
-                    "default": True,
-                    "private": False,
-                },
-                follow_redirects=False,
-                verify=SSLMatcher(),
-                timeout=DEFAULT_TIMEOUT_SECONDS,
-            )
-
-    def test_delete_with_id(self):
-        client = DescopeClient(
-            self.dummy_project_id,
-            self.public_key_dict,
-            False,
-            self.dummy_management_key,
-        )
-
-        # Test failed flow
-        with patch("httpx.post") as mock_post:
-            mock_post.return_value.is_success = False
-            self.assertRaises(
-                AuthException,
-                client.mgmt.role.delete,
-                id="ROL123",
-            )
-
-        # Test success flow
-        with patch("httpx.post") as mock_post:
-            mock_post.return_value.is_success = True
-            self.assertIsNone(client.mgmt.role.delete(tenant_id="t1", id="ROL123"))
+            self.assertIsNone(client.mgmt.role.delete_by_id("ROL123", "t1"))
             mock_post.assert_called_with(
                 f"{common.DEFAULT_BASE_URL}{MgmtV1.role_delete_path}",
                 headers={
@@ -379,7 +379,7 @@ class TestRole(common.DescopeTest):
             self.dummy_management_key,
         )
 
-        # Test failed flow (by names, original call style)
+        # Test failed flow
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = False
             self.assertRaises(
@@ -388,14 +388,16 @@ class TestRole(common.DescopeTest):
                 [{"name": "R1"}],
             )
 
-        # Test success flow — by names with tenantId (original call style)
+        # Test success flow
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
             self.assertIsNone(
-                client.mgmt.role.delete_batch([
-                    {"name": "R1", "tenantId": "t1"},
-                    {"name": "R2"},
-                ])
+                client.mgmt.role.delete_batch(
+                    [
+                        {"name": "R1", "tenantId": "t1"},
+                        {"name": "R2"},
+                    ]
+                )
             )
             mock_post.assert_called_with(
                 f"{common.DEFAULT_BASE_URL}{MgmtV1.role_delete_batch_path}",
@@ -405,18 +407,38 @@ class TestRole(common.DescopeTest):
                     "x-descope-project-id": self.dummy_project_id,
                 },
                 params=None,
-                json={"roleNames": ["R1", "R2"], "tenantId": "t1"},
+                json={
+                    "roles": [
+                        {"name": "R1", "tenantId": "t1"},
+                        {"name": "R2"},
+                    ]
+                },
                 follow_redirects=False,
                 verify=SSLMatcher(),
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
 
-        # Test success flow — by IDs (new kwarg)
+    def test_delete_batch_by_ids(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flow
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.role.delete_batch_by_ids,
+                ["ROL1"],
+            )
+
+        # Test success flow
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
-            self.assertIsNone(
-                client.mgmt.role.delete_batch(role_ids=["ROL1", "ROL2"])
-            )
+            self.assertIsNone(client.mgmt.role.delete_batch_by_ids(["ROL1", "ROL2"], "t1"))
             mock_post.assert_called_with(
                 f"{common.DEFAULT_BASE_URL}{MgmtV1.role_delete_batch_path}",
                 headers={
@@ -425,7 +447,7 @@ class TestRole(common.DescopeTest):
                     "x-descope-project-id": self.dummy_project_id,
                 },
                 params=None,
-                json={"roleIds": ["ROL1", "ROL2"]},
+                json={"roleIds": ["ROL1", "ROL2"], "tenantId": "t1"},
                 follow_redirects=False,
                 verify=SSLMatcher(),
                 timeout=DEFAULT_TIMEOUT_SECONDS,
@@ -584,7 +606,6 @@ class TestRole(common.DescopeTest):
             self.dummy_management_key,
         )
 
-        # Test private=True
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
             self.assertIsNone(
@@ -621,7 +642,6 @@ class TestRole(common.DescopeTest):
             self.dummy_management_key,
         )
 
-        # Test private=True
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
             self.assertIsNone(
@@ -665,7 +685,6 @@ class TestRole(common.DescopeTest):
             self.dummy_management_key,
         )
 
-        # Test without private parameter (should be None)
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
             self.assertIsNone(client.mgmt.role.create("SimpleRole", "Simple role"))

--- a/tests/management/test_role.py
+++ b/tests/management/test_role.py
@@ -438,7 +438,9 @@ class TestRole(common.DescopeTest):
         # Test success flow
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
-            self.assertIsNone(client.mgmt.role.delete_batch_by_ids(["ROL1", "ROL2"], "t1"))
+            self.assertIsNone(
+                client.mgmt.role.delete_batch_by_ids(["ROL1", "ROL2"], "t1")
+            )
             mock_post.assert_called_with(
                 f"{common.DEFAULT_BASE_URL}{MgmtV1.role_delete_batch_path}",
                 headers={
@@ -470,16 +472,14 @@ class TestRole(common.DescopeTest):
         with patch("httpx.get") as mock_get:
             network_resp = mock.Mock()
             network_resp.is_success = True
-            network_resp.json.return_value = json.loads(
-                """
+            network_resp.json.return_value = json.loads("""
                 {
                     "roles": [
                         {"name": "R1", "permissionNames": ["P1", "P2"]},
                         {"name": "R2"}
                     ]
                 }
-                """
-            )
+                """)
             mock_get.return_value = network_resp
             resp = client.mgmt.role.load_all()
             roles = resp["roles"]
@@ -525,16 +525,14 @@ class TestRole(common.DescopeTest):
         with patch("httpx.post") as mock_post:
             network_resp = mock.Mock()
             network_resp.is_success = True
-            network_resp.json.return_value = json.loads(
-                """
+            network_resp.json.return_value = json.loads("""
                 {
                     "roles": [
                         {"name": "R1", "permissionNames": ["P1", "P2"]},
                         {"name": "R2"}
                     ]
                 }
-                """
-            )
+                """)
             mock_post.return_value = network_resp
             resp = client.mgmt.role.search(["t"], ["r"], "x", ["p1", "p2"])
             roles = resp["roles"]
@@ -606,6 +604,7 @@ class TestRole(common.DescopeTest):
             self.dummy_management_key,
         )
 
+        # Test private=True
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
             self.assertIsNone(
@@ -642,6 +641,7 @@ class TestRole(common.DescopeTest):
             self.dummy_management_key,
         )
 
+        # Test private=True
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
             self.assertIsNone(
@@ -685,6 +685,7 @@ class TestRole(common.DescopeTest):
             self.dummy_management_key,
         )
 
+        # Test without private parameter (should be None)
         with patch("httpx.post") as mock_post:
             mock_post.return_value.is_success = True
             self.assertIsNone(client.mgmt.role.create("SimpleRole", "Simple role"))

--- a/tests/management/test_role.py
+++ b/tests/management/test_role.py
@@ -282,6 +282,95 @@ class TestRole(common.DescopeTest):
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
 
+    def test_update_with_id(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flow
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.role.update_with_id,
+                "ROL123",
+                "new-name",
+            )
+
+        # Test success flow
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = True
+            self.assertIsNone(
+                client.mgmt.role.update_with_id(
+                    "ROL123",
+                    "new-name",
+                    "new-description",
+                    ["P1", "P2"],
+                    "t1",
+                    True,
+                    False,
+                )
+            )
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.role_update_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                    "x-descope-project-id": self.dummy_project_id,
+                },
+                params=None,
+                json={
+                    "id": "ROL123",
+                    "newName": "new-name",
+                    "description": "new-description",
+                    "permissionNames": ["P1", "P2"],
+                    "tenantId": "t1",
+                    "default": True,
+                    "private": False,
+                },
+                follow_redirects=False,
+                verify=SSLMatcher(),
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+
+    def test_delete_with_id(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flow
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.role.delete_with_id,
+                "ROL123",
+            )
+
+        # Test success flow
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = True
+            self.assertIsNone(client.mgmt.role.delete_with_id("ROL123", "t1"))
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.role_delete_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                    "x-descope-project-id": self.dummy_project_id,
+                },
+                params=None,
+                json={"id": "ROL123", "tenantId": "t1"},
+                follow_redirects=False,
+                verify=SSLMatcher(),
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+
     def test_delete_batch(self):
         client = DescopeClient(
             self.dummy_project_id,
@@ -435,6 +524,40 @@ class TestRole(common.DescopeTest):
                     "roleNameLike": "x",
                     "permissionNames": ["p1", "p2"],
                 },
+                follow_redirects=False,
+                verify=SSLMatcher(),
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+
+    def test_search_by_role_ids(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        with patch("httpx.post") as mock_post:
+            network_resp = mock.Mock()
+            network_resp.is_success = True
+            network_resp.json.return_value = json.loads(
+                """{"roles": [{"id": "ROL123", "name": "R1"}]}"""
+            )
+            mock_post.return_value = network_resp
+            resp = client.mgmt.role.search(role_ids=["ROL123"])
+            roles = resp["roles"]
+            self.assertEqual(len(roles), 1)
+            self.assertEqual(roles[0]["id"], "ROL123")
+            self.assertEqual(roles[0]["name"], "R1")
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.role_search_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                    "x-descope-project-id": self.dummy_project_id,
+                },
+                params=None,
+                json={"roleIds": ["ROL123"]},
                 follow_redirects=False,
                 verify=SSLMatcher(),
                 timeout=DEFAULT_TIMEOUT_SECONDS,


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/15352

## Related PRs
### Upstream PRs
- https://github.com/descope/descope/pull/692
- https://github.com/descope/go-sdk/pull/740

### Downstream PRs
- https://github.com/descope/integrationtests/pull/13850

## Description
Adds explicit `_by_id` methods alongside existing ones for Roles and Permissions CRUD, keeping the API clean, simple and fully backwards compatible.

**Permission** — new methods:
- `update_by_id(id, new_name, description)` 
- `delete_by_id(id)`
- `delete_batch_by_ids(ids)`

**Role** — new methods:
- `update_by_id(id, new_name, description, permission_names, tenant_id, default, private)`
- `delete_by_id(id, tenant_id)`
- `delete_batch_by_ids(role_ids, tenant_id)`
- `search(..., role_ids)` — new optional filter param (additive, backward compatible)

## Must
- [x] Tests