### PR TITLE
ci(release-please): sync uv.lock after version bump

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      pr_branch: ${{ steps.pr_info.outputs.branch }}
     steps:
       - name: Generate GitHub App Token
         id: app-token
@@ -29,6 +30,61 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Extract release-please PR branch
+        id: pr_info
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          branch="$(echo "$PR_JSON" | jq -r '.headBranchName')"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+  sync-uv-lock:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.pr_branch != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PEM }}
+
+      - name: Checkout release-please PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.release-please.outputs.pr_branch }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          python-version: "3.13"
+
+      - name: Sync uv.lock with bumped version
+        run: uv lock
+
+      - name: Commit and push if changed
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          PR_BRANCH: ${{ needs.release-please.outputs.pr_branch }}
+        run: |
+          if git diff --quiet uv.lock; then
+            echo "uv.lock already in sync; nothing to do."
+            exit 0
+          fi
+          APP_USER_ID="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config user.name  "${APP_SLUG}[bot]"
+          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore: sync uv.lock with release version"
+          git push origin "HEAD:${PR_BRANCH}"
 
   publish:
     needs: release-please


### PR DESCRIPTION
## Why

The release-please PR (#1446) is failing every CI job with:

```
The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
To update the lockfile, run `uv lock`.
```

Root cause: release-please bumps `version` in `pyproject.toml` (`1.13.0` → `2.0.0`) but doesn't touch `uv.lock`. Since `uv.lock` records the project's own version (the `[[package]] name = "descope"` entry), `uv sync --locked` fails the integrity check on the next CI run.

Reproduced locally:

```bash
sed -i 's/^version = "1.13.0"/version = "2.0.0"/' pyproject.toml
uv sync --all-extras --locked
# → "The lockfile at `uv.lock` needs to be updated, but `--locked` was provided"
uv lock
# → "Updated descope v1.13.0 -> v2.0.0"
uv sync --all-extras --locked   # passes
```

## What

Add a `sync-uv-lock` job after `release-please-action` that:

1. Reads the PR object from `release-please-action`'s `pr` output and extracts `headBranchName`.
2. Runs only when a release PR was opened/updated (`pr_branch != ''`).
3. Checks out the release-please PR branch using the same GitHub App token.
4. Runs `uv lock` to re-sync the project version in `uv.lock`.
5. Commits and pushes back to the PR branch only if `uv.lock` actually changed.
6. Uses the App's bot identity for the commit so it appears alongside release-please's own commits.

The push uses the App token (not `GITHUB_TOKEN`), so PR CI re-triggers automatically with the fixed lockfile.

If release-please regenerates the PR later (e.g. new commits land on `main`), the workflow re-runs on the next push to `main` and re-applies the sync — the lock stays in sync without manual intervention.

## Out of scope

- The `publish` job is unchanged — it runs at tag time, after the PR is merged, where `uv.lock` is already fixed.
- We don't try to add `uv.lock` to release-please's `extra-files` because release-please's TOML updater can't address `[[package]] name = "descope"` array entries cleanly.

## Verification

- Workflow YAML lints clean (`actionlint`).
- Local reproduction shows `uv lock` is the exact remediation needed.
- After this lands and release-please regenerates #1446, the PR's CI should go green.