### PR TITLE
chore(deps): drop unused mock and types-setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ Documentation = "https://docs.descope.com"
 
 [dependency-groups]
 dev = [
-    "mock==5.2.0",
     "pre-commit==3.8.0",
     "ruff==0.15.12",
 ]
@@ -50,7 +49,6 @@ types = [
     # mypy is only run in the lint job (Python 3.13) so 3.9 never installs it in CI.
     "mypy>=1.20.1; python_version >= '3.10'",
     "mypy==1.11.2; python_version < '3.10'",
-    "types-setuptools==75.8.2.20250305",
 ]
 tests = [
     # pytest 9 requires Python 3.10+; on 3.9 we stay on the last 8.x line.
@@ -119,7 +117,6 @@ safe_licenses = [
     "MIT License",
     "MIT",
     "ISC License (ISCL)",
-    "Apache Software License",
     "Apache-2.0",
     "BSD License",
     "BSD-2-Clause",

--- a/uv.lock
+++ b/uv.lock
@@ -539,7 +539,6 @@ flask = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "mock" },
     { name = "pre-commit" },
     { name = "ruff" },
 ]
@@ -553,7 +552,6 @@ tests = [
 types = [
     { name = "mypy", version = "1.11.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "mypy", version = "1.20.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "types-setuptools" },
 ]
 
 [package.metadata]
@@ -568,7 +566,6 @@ provides-extras = ["flask"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mock", specifier = "==5.2.0" },
     { name = "pre-commit", specifier = "==3.8.0" },
     { name = "ruff", specifier = "==0.15.12" },
 ]
@@ -581,7 +578,6 @@ tests = [
 types = [
     { name = "mypy", marker = "python_full_version < '3.10'", specifier = "==1.11.2" },
     { name = "mypy", marker = "python_full_version >= '3.10'", specifier = ">=1.20.1" },
-    { name = "types-setuptools", specifier = "==75.8.2.20250305" },
 ]
 
 [[package]]
@@ -1012,15 +1008,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mock"
-version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/07/8c/14c2ae915e5f9dca5a22edd68b35be94400719ccfa068a03e0fb63d0f6f6/mock-5.2.0.tar.gz", hash = "sha256:4e460e818629b4b173f32d08bf30d3af8123afbb8e04bb5707a1fd4799e503f0", size = 92796, upload-time = "2025-03-03T12:31:42.911Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/d9/617e6af809bf3a1d468e0d58c3997b1dc219a9a9202e650d30c2fc85d481/mock-5.2.0-py3-none-any.whl", hash = "sha256:7ba87f72ca0e915175596069dbbcc7c75af7b5e9b9bc107ad6349ede0819982f", size = 31617, upload-time = "2025-03-03T12:31:41.518Z" },
-]
-
-[[package]]
 name = "mypy"
 version = "1.11.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1431,15 +1418,6 @@ wheels = [
 ]
 
 [[package]]
-name = "setuptools"
-version = "82.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
-]
-
-[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1491,18 +1469,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
-]
-
-[[package]]
-name = "types-setuptools"
-version = "75.8.2.20250305"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/18/a996861f5225e7d533a8d8b6aa61bcc9183429a6b8bc93b850aa2e22974d/types_setuptools-75.8.2.20250305.tar.gz", hash = "sha256:a987269b49488f21961a1d99aa8d281b611625883def6392a93855b31544e405", size = 42609, upload-time = "2025-03-05T02:47:51.104Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/5b/bb33f99239a6d54ed1d8220a088d96d2ccacac7abb317df0d68d2500f3be/types_setuptools-75.8.2.20250305-py3-none-any.whl", hash = "sha256:ba80953fd1f5f49e552285c024f75b5223096a38a5138a54d18ddd3fa8f6a2d4", size = 63727, upload-time = "2025-03-05T02:47:49.12Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Audit of every declared dependency vs actual import sites surfaced two packages that aren't used by anything in this repo. Drop them.

| Package | Group | Status | Evidence |
|---|---|---|---|
| `mock==5.2.0` | dev | **unused** | All `mock.Mock()` / `mock.patch` calls come from `from unittest import mock` (stdlib). Zero `^import mock` or `^from mock` in `tests/`, `samples/`, or `descope/`. The third-party `mock` package is a backport for Python <3.3 — irrelevant since we require 3.9+. |
| `types-setuptools==75.8.2.20250305` | types | **unused** | Zero `import setuptools`, `import pkg_resources`, `import distutils` anywhere. Was originally needed for typing the `pkg_resources` fallback in `http_client.sdk_version`, which was removed in #1453 once we standardized on `importlib.metadata`. |

## What stays

Verified each remaining dep is actually imported:

- `httpx` — `descope/http_client.py` etc. (4 src files)
- `certifi` — `descope/http_client.py` (`certifi.where()` for SSL CA bundle)
- `pyjwt[crypto]` — `descope/auth.py`, `descope/jwt_common.py` (imported as `import jwt`)
- `email-validator` — `descope/auth.py`
- `Flask` (extra) — `descope/flask/__init__.py`, samples
- `pre-commit`, `ruff`, `mypy` — actual CI/dev tooling
- `coverage[toml]` — invoked directly in CI as `uv run coverage run -m pytest`
- `pytest-cov` — supports the `--cov` form documented in README (intentionally added in #1453)

## Knock-on cleanup

Drops `Apache Software License` from `[tool.pylic].safe_licenses`. `types-setuptools` was the only installed package whose metadata used that long-form name; remaining Apache-licensed deps (`coverage`, `cryptography`) declare `Apache-2.0` which is already listed.

## Why this matters

Several open Renovate PRs are bumping `types-setuptools` (#777 v82, #776 v81, #573 v80, #567 v79, #553 v78, etc). They've all been failing CI for unrelated reasons but they're also pure noise — the dep is unused. Closing this gap kills the noise at the source.

## Verification

- `uv sync --all-extras --locked` — clean (60 → 60 - 3 packages)
- `uv run ruff check .` / `ruff format --check` — clean
- `uv run mypy descope tests samples` — no issues (107 files)
- `uv run pytest tests` — 458 passed on Python 3.9 and 3.13
- `uv run --with pylic pylic check` — ✨ All licenses ok ✨