### PR TITLE
ci(release-please): bump uv.lock version via extra-files jsonpath

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,11 @@
           "type": "toml",
           "path": "pyproject.toml",
           "jsonpath": "$.project.version"
+        },
+        {
+          "type": "toml",
+          "path": "uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='descope')].version"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Replaces #1515 with a much simpler fix: just one extra entry in `release-please-config.json` instead of an entire follow-up workflow job + GitHub App token + push-back-to-PR-branch dance.

## Background

`release-please` bumps `version` in `pyproject.toml` but doesn't update `uv.lock`. The project's own version lives in `uv.lock` too:

```toml
[[package]]
name = "descope"
version = "1.13.0"
```

So `uv sync --locked` fails on every CI job for the release PR (#1446) with `The lockfile at uv.lock needs to be updated`.

## Fix

Per [googleapis/release-please#2561](https://github.com/googleapis/release-please/issues/2561) and the working incantation documented in [#2455 (comment)](https://github.com/googleapis/release-please/issues/2455#issuecomment-2643132770), `release-please`'s TOML updater **can** target array-of-tables entries via a jsonpath filter — with one quirk:

- the filter side needs `.value` because release-please's TOML parser wraps strings as `{value, start, end}` objects
- the update target does **not** use `.value` because the updater writes to the field directly

Resulting jsonpath:

```
$.package[?(@.name.value=='descope')].version
```

## Why this approach over #1515

| | #1515 (workflow job) | This PR (config) |
|---|---|---|
| Files changed | `.github/workflows/release-please.yml` (+55 lines) | `release-please-config.json` (+5 lines) |
| Mechanism | Run `uv lock` after release-please, push commit back | Native release-please feature |
| Auth required | GitHub App token w/ `contents: write` | None |
| Race conditions | Possible if release-please regenerates between steps | None — atomic |
| Maintenance | Custom code, may drift | Standard release-please config |

Closing #1515 in favor of this.

## Verification

- Config JSON parses cleanly.
- jsonpath structure verified to target the correct `[[package]]` entry (descope's at line 523-526 of `uv.lock`).
- The pattern is the documented working solution; will produce the bumped `uv.lock` on the next release-please run after merge.