### PR TITLE
feat(tenant): add jit sso link generation method

### DIFF
--- a/descope/management/common.py
+++ b/descope/management/common.py
@@ -97,6 +97,7 @@ class MgmtV1:
     tenant_load_all_path = "/v1/mgmt/tenant/all"
     tenant_search_all_path = "/v1/mgmt/tenant/search"
     tenant_update_default_roles_path = "/v1/mgmt/tenant/updateDefaultRoles"
+    tenant_generate_jit_sso_link_path = "/v2/mgmt/tenant/adminlinks/sso/generate"
 
     # sso application
     sso_application_oidc_create_path = "/v1/mgmt/sso/idp/app/oidc/create"

--- a/descope/management/tenant.py
+++ b/descope/management/tenant.py
@@ -200,6 +200,37 @@ class Tenant(HTTPBase):
             body={"id": tenant_id, "defaultRoles": role_names},
         )
 
+    def generate_jit_sso_link(
+        self,
+        tenant_id: str,
+        expire_time: Optional[int] = None,
+    ) -> dict:
+        """
+        Generate a JIT (Just-In-Time) SSO link for the given tenant.
+        This link can be used to set up SSO configuration for a tenant.
+
+        Args:
+        tenant_id (str): The ID of the tenant to generate the SSO link for.
+        expire_time (int): Optional duration in seconds for how long the link should be valid.
+            For example, for a link valid for 6 hours, use 21600 (6 * 60 * 60).
+            If not specified, the default expiration time will be used.
+
+        Return value (dict):
+        Return dict containing the generated SSO link information.
+
+        Raise:
+        AuthException: raised if link generation fails
+        """
+        body: dict[str, Any] = {"tenantId": tenant_id}
+        if expire_time is not None:
+            body["expireTime"] = expire_time
+
+        response = self._http.post(
+            MgmtV1.tenant_generate_jit_sso_link_path,
+            body=body,
+        )
+        return response.json()
+
     def delete(
         self,
         id: str,

--- a/tests/management/test_tenant.py
+++ b/tests/management/test_tenant.py
@@ -610,3 +610,67 @@ class TestTenant(common.DescopeTest):
                 verify=SSLMatcher(),
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
+
+    def test_generate_jit_sso_link(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flows
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.tenant.generate_jit_sso_link,
+                "valid-id",
+            )
+
+        # Test success flow without expire_time
+        with patch("httpx.post") as mock_post:
+            network_resp = mock.Mock()
+            network_resp.is_success = True
+            network_resp.json.return_value = json.loads("""{"link": "https://example.com/sso/setup/token123"}""")
+            mock_post.return_value = network_resp
+            resp = client.mgmt.tenant.generate_jit_sso_link("t1")
+            self.assertEqual(resp["link"], "https://example.com/sso/setup/token123")
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.tenant_generate_jit_sso_link_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                    "x-descope-project-id": self.dummy_project_id,
+                },
+                params=None,
+                json={"tenantId": "t1"},
+                follow_redirects=False,
+                verify=SSLMatcher(),
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+
+        # Test success flow with expire_time (6 hours = 21600 seconds)
+        with patch("httpx.post") as mock_post:
+            network_resp = mock.Mock()
+            network_resp.is_success = True
+            network_resp.json.return_value = json.loads(
+                """{"link": "https://example.com/sso/setup/token456", "expiresAt": 1234567890}"""
+            )
+            mock_post.return_value = network_resp
+            resp = client.mgmt.tenant.generate_jit_sso_link("t1", expire_time=21600)
+            self.assertEqual(resp["link"], "https://example.com/sso/setup/token456")
+            self.assertEqual(resp["expiresAt"], 1234567890)
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.tenant_generate_jit_sso_link_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                    "x-descope-project-id": self.dummy_project_id,
+                },
+                params=None,
+                json={"tenantId": "t1", "expireTime": 21600},
+                follow_redirects=False,
+                verify=SSLMatcher(),
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )


### PR DESCRIPTION
Fixes descope/etc#15591

[View workflow run](https://github.com/descope/shuni/actions/runs/25796590037)

Perfect! I've successfully implemented the JIT SSO link generation feature for the Python SDK. Here's what was done:

## Changes Made

### 1. **API Path Constant** (`descope/management/common.py`)
   - Added `tenant_generate_jit_sso_link_path = "/v2/mgmt/tenant/adminlinks/sso/generate"`

### 2. **Method Implementation** (`descope/management/tenant.py`)
   - Added `generate_jit_sso_link(tenant_id, expire_time=None)` method
   - Parameters:
     - `tenant_id` (str, required): The tenant ID to generate the SSO link for
     - `expire_time` (int, optional): Duration in seconds for link validity (e.g., 21600 for 6 hours)
   - Returns: dict containing the generated SSO link information

### 3. **Comprehensive Tests** (`tests/management/test_tenant.py`)
   - Test for failure scenarios
   - Test for success without `expire_time`
   - Test for success with `expire_time` parameter (6 hours = 21600 seconds)
   - All tests follow existing patterns using mock.patch

## Quality Gate Results ✅

- **Format**: ✅ Passed (auto-fixed test file formatting)
- **Lint**: ✅ Passed (no issues found)
- **Typecheck**: ✅ Passed (mypy validated successfully)
- **Tests**: ✅ Passed (10/10 tenant tests including new test)

## Usage Example

```python
from descope import DescopeClient

client = DescopeClient(project_id, management_key=mgmt_key)

# Generate SSO link with default expiration
result = client.mgmt.tenant.generate_jit_sso_link("tenant-id")
print(result["link"])

# Generate SSO link valid for 6 hours
result = client.mgmt.tenant.generate_jit_sso_link("tenant-id", expire_time=21600)
print(result["link"])
```

The implementation follows all existing SDK patterns and is ready for use! 🎉

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*