### PR TITLE
feat(tenant): add method for jit sso link generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,13 @@ tenants_resp = descope_client.mgmt.tenant.search_all(ids=["id1"], names=["name1"
 tenants = tenants_resp["tenants"]
     for tenant in tenants:
         # Do something
+
+# Generate tenant admin self-service link for SSO configuration
+# The link will be valid for the specified duration in seconds (e.g., 21600 seconds = 6 hours)
+sso_link = descope_client.mgmt.tenant.generate_sso_configuration_link(
+    tenant_id="my-custom-id",
+    expire_time=21600  # 6 hours in seconds
+)
 ```
 
 ### Manage Users

--- a/descope/management/common.py
+++ b/descope/management/common.py
@@ -97,6 +97,7 @@ class MgmtV1:
     tenant_load_all_path = "/v1/mgmt/tenant/all"
     tenant_search_all_path = "/v1/mgmt/tenant/search"
     tenant_update_default_roles_path = "/v1/mgmt/tenant/updateDefaultRoles"
+    tenant_generate_sso_configuration_link_path = "/v2/mgmt/tenant/adminlinks/sso/generate"
 
     # sso application
     sso_application_oidc_create_path = "/v1/mgmt/sso/idp/app/oidc/create"

--- a/descope/management/tenant.py
+++ b/descope/management/tenant.py
@@ -326,6 +326,34 @@ class Tenant(HTTPBase):
         )
         return response.json()
 
+    def generate_sso_configuration_link(
+        self,
+        tenant_id: str,
+        expire_time: int,
+    ) -> str:
+        """
+        Generate a tenant admin self-service link for SSO configuration.
+
+        Args:
+        tenant_id (str): The ID of the tenant to generate the link for.
+        expire_time (int): The expiration duration in seconds. For a link valid for 6 hours, use 21600.
+
+        Return value (str):
+        Returns the admin SSO configuration link as a string.
+
+        Raise:
+        AuthException: raised if generation operation fails
+        """
+        response = self._http.post(
+            MgmtV1.tenant_generate_sso_configuration_link_path,
+            body={
+                "tenantId": tenant_id,
+                "expireTime": expire_time,
+            },
+        )
+        result = response.json()
+        return result.get("adminSSOConfigurationLink", "")
+
     @staticmethod
     def _compose_create_update_body(
         name: str,

--- a/tests/management/test_tenant.py
+++ b/tests/management/test_tenant.py
@@ -610,3 +610,56 @@ class TestTenant(common.DescopeTest):
                 verify=SSLMatcher(),
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
+
+    def test_generate_sso_configuration_link_success(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test success flow
+        with patch("httpx.post") as mock_post:
+            network_resp = mock.Mock()
+            network_resp.is_success = True
+            network_resp.json.return_value = json.loads(
+                """{"adminSSOConfigurationLink": "https://example.com/sso-config-link"}"""
+            )
+            mock_post.return_value = network_resp
+            link = client.mgmt.tenant.generate_sso_configuration_link("t1", 21600)
+            self.assertEqual(link, "https://example.com/sso-config-link")
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.tenant_generate_sso_configuration_link_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                    "x-descope-project-id": self.dummy_project_id,
+                },
+                params=None,
+                json={
+                    "tenantId": "t1",
+                    "expireTime": 21600,
+                },
+                follow_redirects=False,
+                verify=SSLMatcher(),
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+
+    def test_generate_sso_configuration_link_failed(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test failed flow
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.is_success = False
+            self.assertRaises(
+                AuthException,
+                client.mgmt.tenant.generate_sso_configuration_link,
+                "t1",
+                21600,
+            )


### PR DESCRIPTION
Fixes descope/etc#15591

[View workflow run](https://github.com/descope/shuni/actions/runs/25800239876)

Perfect! I've successfully implemented the `generate_sso_configuration_link` method in the Python SDK, following the pattern from the Go SDK PR #457.

## Summary of Changes

### 1. **API Path Constant** (`descope/management/common.py`)
   - Added `tenant_generate_sso_configuration_link_path = "/v2/mgmt/tenant/adminlinks/sso/generate"`

### 2. **Method Implementation** (`descope/management/tenant.py`)
   - Added `generate_sso_configuration_link(tenant_id: str, expire_time: int) -> str`
   - Parameters:
     - `tenant_id`: The tenant ID
     - `expire_time`: Expiration duration in seconds (e.g., 21600 for 6 hours)
   - Returns: The admin SSO configuration link as a string

### 3. **Tests** (`tests/management/test_tenant.py`)
   - `test_generate_sso_configuration_link_success`: Verifies successful link generation
   - `test_generate_sso_configuration_link_failed`: Verifies error handling

### 4. **Documentation** (`README.md`)
   - Added usage example in the "Manage Tenants" section

## Quality Gate Results ✅
- **Format**: ✅ All files properly formatted (ruff format)
- **Lint**: ✅ All checks passed (ruff check)
- **Tests**: ✅ 11/11 tests passed (including 2 new tests)

## Implementation Details
- **Endpoint**: `POST /v2/mgmt/tenant/adminlinks/sso/generate`
- **Request**: `{"tenantId": string, "expireTime": int}`
- **Response**: `{"adminSSOConfigurationLink": string}`

The implementation follows the exact pattern from the Go SDK and is consistent with existing Python SDK conventions. All tests pass and code quality checks are green! 🎉

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*