### PR TITLE
fix(deps): pin mypy to 1.11.2 for Python < 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ types = [
     # mypy 1.12+ requires Python 3.10+; on 3.9 we stay on the last 1.11.x line.
     # mypy is only run in the lint job (Python 3.13) so 3.9 never installs it in CI.
     "mypy>=1.20.1; python_version >= '3.10'",
-    "mypy==1.20.2; python_version < '3.10'",
+    "mypy==1.11.2; python_version < '3.10'",
 ]
 tests = [
     # pytest 9 requires Python 3.10+; on 3.9 we stay on the last 8.x line.


### PR DESCRIPTION
Fixes regression introduced in #1526.

mypy 1.20.x dropped Python 3.9 support, so the Python-version-conditional pin `mypy==1.11.2; python_version < '3.10'` must stay on the 1.11.x line. A renovate bump in #1526 incorrectly updated that pin to 1.20.2, which made `uv sync --all-extras` unsatisfiable for Python 3.9 targets.