### PR TITLE
feat: add locale to invite and invite_batch

### DIFF
--- a/descope/management/user.py
+++ b/descope/management/user.py
@@ -244,6 +244,7 @@ class User(HTTPBase):
         sso_app_ids: Optional[List[str]] = None,
         template_id: str = "",
         test: bool = False,
+        locale: Optional[str] = None,  # locale for the invite message
     ) -> dict:
         """
         Create a new user and invite them via an email / text message.
@@ -283,6 +284,7 @@ class User(HTTPBase):
                 additional_login_ids,
                 sso_app_ids,
                 template_id,
+                locale,
             ),
         )
         return response.json()
@@ -293,6 +295,7 @@ class User(HTTPBase):
         invite_url: Optional[str] = None,
         send_mail: Optional[bool] = None,  # send invite via mail, default is according to project settings
         send_sms: Optional[bool] = None,  # send invite via text message, default is according to project settings
+        locale: Optional[str] = None,  # locale for the invite message
     ) -> dict:
         """
         Create users in batch and invite them via an email / text message.
@@ -313,6 +316,7 @@ class User(HTTPBase):
                 invite_url,
                 send_mail,
                 send_sms,
+                locale,
             ),
         )
         return response.json()
@@ -1860,6 +1864,7 @@ class User(HTTPBase):
         additional_login_ids: Optional[List[str]],
         sso_app_ids: Optional[List[str]] = None,
         template_id: str = "",
+        locale: Optional[str] = None,
     ) -> dict:
         body = User._compose_update_body(
             login_id=login_id,
@@ -1890,6 +1895,8 @@ class User(HTTPBase):
             body["sendSMS"] = send_sms
         if template_id != "":
             body["templateId"] = template_id
+        if locale is not None:
+            body["locale"] = locale
         return body
 
     @staticmethod
@@ -1898,6 +1905,7 @@ class User(HTTPBase):
         invite_url: Optional[str],
         send_mail: Optional[bool],
         send_sms: Optional[bool],
+        locale: Optional[str] = None,
     ) -> dict:
         usersBody = []
         for user in users:
@@ -1940,6 +1948,8 @@ class User(HTTPBase):
             body["sendMail"] = send_mail
         if send_sms is not None:
             body["sendSMS"] = send_sms
+        if locale is not None:
+            body["locale"] = locale
         return body
 
     @staticmethod

--- a/tests/management/test_user.py
+++ b/tests/management/test_user.py
@@ -241,6 +241,7 @@ class TestUser(common.DescopeTest):
                 send_sms=True,
                 sso_app_ids=["app1", "app2"],
                 template_id="tid",
+                locale="en",
             )
             user = resp["user"]
             self.assertEqual(user["id"], "u1")
@@ -271,6 +272,7 @@ class TestUser(common.DescopeTest):
                     "additionalLoginIds": None,
                     "ssoAppIDs": ["app1", "app2"],
                     "templateId": "tid",
+                    "locale": "en",
                 },
                 follow_redirects=False,
                 verify=SSLMatcher(),
@@ -320,6 +322,7 @@ class TestUser(common.DescopeTest):
                 users=[user],
                 invite_url="invite.me",
                 send_sms=True,
+                locale="en",
             )
             users = resp["users"]
             self.assertEqual(users[0]["id"], "u1")
@@ -361,6 +364,7 @@ class TestUser(common.DescopeTest):
                 "invite": True,
                 "inviteUrl": "invite.me",
                 "sendSMS": True,
+                "locale": "en",
             }
             mock_post.assert_called_with(
                 f"{common.DEFAULT_BASE_URL}{MgmtV1.user_create_batch_path}",
@@ -400,6 +404,7 @@ class TestUser(common.DescopeTest):
                 users=[user],
                 invite_url="invite.me",
                 send_sms=True,
+                locale="en",
             )
 
             del expected_users["users"][0]["hashedPassword"]
@@ -423,6 +428,7 @@ class TestUser(common.DescopeTest):
                 users=[user],
                 invite_url="invite.me",
                 send_sms=True,
+                locale="en",
             )
 
             del expected_users["users"][0]["password"]


### PR DESCRIPTION
## Description

Adds an optional `locale` parameter to `user.invite` and `user.invite_batch` to control the language of the invite message sent to the user.

Mirrors the equivalent change in the node-sdk: descope/node-sdk#735

The `locale` value is passed through to the `locale` field in the user create / batch-create request body.

## Changes
- `descope/management/user.py`: add `locale` param to `invite`, `invite_batch`, and the `_compose_create_body` / `_compose_create_batch_body` helpers
- `tests/management/test_user.py`: cover the new param in the invite and invite_batch tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)