### PR TITLE
feat(tenant): add optional user_id/login_id actor to generate_sso_configuration_link

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,6 +645,15 @@ sso_link = descope_client.mgmt.tenant.generate_sso_configuration_link(
     tenant_id="my-custom-id",
     expire_time=21600  # 6 hours in seconds
 )
+
+# Optionally bind the link to a real user (by user_id or login_id) so actions taken inside the
+# SSO Suite are audited against that user instead of a temporary one. The user must exist and
+# belong to the tenant; user_id takes precedence over login_id.
+sso_link = descope_client.mgmt.tenant.generate_sso_configuration_link(
+    tenant_id="my-custom-id",
+    expire_time=21600,
+    login_id="admin@my-tenant.com",
+)
 ```
 
 ### Manage Users

--- a/README.md
+++ b/README.md
@@ -646,13 +646,12 @@ sso_link = descope_client.mgmt.tenant.generate_sso_configuration_link(
     expire_time=21600  # 6 hours in seconds
 )
 
-# Optionally bind the link to a real user (by user_id or login_id) so actions taken inside the
-# SSO Suite are audited against that user instead of a temporary one. The user must exist and
-# belong to the tenant; user_id takes precedence over login_id.
+# Optionally set an actor id, recorded as the audit actor for actions taken inside the SSO
+# Suite (instead of the temporary user). It is used as-is for audit attribution and is not validated.
 sso_link = descope_client.mgmt.tenant.generate_sso_configuration_link(
     tenant_id="my-custom-id",
     expire_time=21600,
-    login_id="admin@my-tenant.com",
+    actor_id="my-admin-actor-id",
 )
 ```
 

--- a/descope/management/tenant.py
+++ b/descope/management/tenant.py
@@ -332,8 +332,7 @@ class Tenant(HTTPBase):
         expire_time: Optional[int] = None,
         email: Optional[str] = None,
         sso_id: Optional[str] = None,
-        user_id: Optional[str] = None,
-        login_id: Optional[str] = None,
+        actor_id: Optional[str] = None,
     ) -> str:
         """
         Generate a tenant admin self-service link for SSO configuration.
@@ -343,10 +342,9 @@ class Tenant(HTTPBase):
         expire_time (int): Optional expiration duration in seconds. For a link valid for 6 hours, use 21600.
         email (str): Optional email address associated with the admin.
         sso_id (str): Optional SSO identifier for the tenant.
-        user_id (str): Optional Descope user ID. When provided, the SSO Setup Suite session is
-            attributed to that real user so actions are audited against them instead of a temporary
-            user. The user must exist and belong to the tenant. Takes precedence over login_id.
-        login_id (str): Optional login identifier for the same purpose as user_id.
+        actor_id (str): Optional id recorded as the audit actor for actions performed inside the
+            SSO Setup Suite (instead of the temporary user). It is used as-is for audit attribution
+            and is not validated.
 
         Return value (str):
         Returns the admin SSO configuration link as a string.
@@ -361,10 +359,8 @@ class Tenant(HTTPBase):
             body["email"] = email
         if sso_id is not None:
             body["ssoId"] = sso_id
-        if user_id is not None:
-            body["userId"] = user_id
-        if login_id is not None:
-            body["loginId"] = login_id
+        if actor_id is not None:
+            body["actorId"] = actor_id
 
         response = self._http.post(
             MgmtV1.tenant_generate_sso_configuration_link_path,

--- a/descope/management/tenant.py
+++ b/descope/management/tenant.py
@@ -332,6 +332,8 @@ class Tenant(HTTPBase):
         expire_time: Optional[int] = None,
         email: Optional[str] = None,
         sso_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        login_id: Optional[str] = None,
     ) -> str:
         """
         Generate a tenant admin self-service link for SSO configuration.
@@ -341,6 +343,10 @@ class Tenant(HTTPBase):
         expire_time (int): Optional expiration duration in seconds. For a link valid for 6 hours, use 21600.
         email (str): Optional email address associated with the admin.
         sso_id (str): Optional SSO identifier for the tenant.
+        user_id (str): Optional Descope user ID. When provided, the SSO Setup Suite session is
+            attributed to that real user so actions are audited against them instead of a temporary
+            user. The user must exist and belong to the tenant. Takes precedence over login_id.
+        login_id (str): Optional login identifier for the same purpose as user_id.
 
         Return value (str):
         Returns the admin SSO configuration link as a string.
@@ -355,6 +361,10 @@ class Tenant(HTTPBase):
             body["email"] = email
         if sso_id is not None:
             body["ssoId"] = sso_id
+        if user_id is not None:
+            body["userId"] = user_id
+        if login_id is not None:
+            body["loginId"] = login_id
 
         response = self._http.post(
             MgmtV1.tenant_generate_sso_configuration_link_path,

--- a/tests/management/test_tenant.py
+++ b/tests/management/test_tenant.py
@@ -746,7 +746,7 @@ class TestTenant(common.DescopeTest):
             self.dummy_management_key,
         )
 
-        # Test that user_id and login_id are sent to attribute the suite session to a real user
+        # Test that actor_id is sent and recorded as the audit actor for in-suite actions
         with patch("httpx.post") as mock_post:
             network_resp = mock.Mock()
             network_resp.is_success = True
@@ -756,8 +756,7 @@ class TestTenant(common.DescopeTest):
             mock_post.return_value = network_resp
             link = client.mgmt.tenant.generate_sso_configuration_link(
                 tenant_id="t1",
-                user_id="user-1",
-                login_id="admin@example.com",
+                actor_id="admin-actor-1",
             )
             self.assertEqual(link, "https://example.com/sso-config-link")
             mock_post.assert_called_with(
@@ -770,8 +769,7 @@ class TestTenant(common.DescopeTest):
                 params=None,
                 json={
                     "tenantId": "t1",
-                    "userId": "user-1",
-                    "loginId": "admin@example.com",
+                    "actorId": "admin-actor-1",
                 },
                 follow_redirects=False,
                 verify=SSLMatcher(),

--- a/tests/management/test_tenant.py
+++ b/tests/management/test_tenant.py
@@ -737,3 +737,43 @@ class TestTenant(common.DescopeTest):
                 verify=SSLMatcher(),
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
+
+    def test_generate_sso_configuration_link_with_actor(self):
+        client = DescopeClient(
+            self.dummy_project_id,
+            self.public_key_dict,
+            False,
+            self.dummy_management_key,
+        )
+
+        # Test that user_id and login_id are sent to attribute the suite session to a real user
+        with patch("httpx.post") as mock_post:
+            network_resp = mock.Mock()
+            network_resp.is_success = True
+            network_resp.json.return_value = json.loads(
+                """{"adminSSOConfigurationLink": "https://example.com/sso-config-link"}"""
+            )
+            mock_post.return_value = network_resp
+            link = client.mgmt.tenant.generate_sso_configuration_link(
+                tenant_id="t1",
+                user_id="user-1",
+                login_id="admin@example.com",
+            )
+            self.assertEqual(link, "https://example.com/sso-config-link")
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{MgmtV1.tenant_generate_sso_configuration_link_path}",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:{self.dummy_management_key}",
+                    "x-descope-project-id": self.dummy_project_id,
+                },
+                params=None,
+                json={
+                    "tenantId": "t1",
+                    "userId": "user-1",
+                    "loginId": "admin@example.com",
+                },
+                follow_redirects=False,
+                verify=SSLMatcher(),
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )


### PR DESCRIPTION
## Description
`mgmt.tenant.generate_sso_configuration_link` now accepts optional `user_id` and `login_id` kwargs. When provided, the SSO Setup Suite session is attributed to that real user (who must exist and belong to the tenant) so actions performed inside the suite are audited against them instead of the temporary user. `user_id` takes precedence over `login_id`; omitting them preserves existing behavior.

Pairs with the backend change: descope/backend#1335 (resolves descope/etc#16281).

## Changes
- `user_id`/`login_id` kwargs added; included in the request body only when set.
- README + unit test.