### PR TITLE
feat(otp): add mfa option to OTP update phone/email

### DIFF
--- a/descope/authmethod/otp.py
+++ b/descope/authmethod/otp.py
@@ -170,6 +170,7 @@ class OTP(AuthBase):
         template_options: dict | None = None,
         template_id: str | None = None,
         provider_id: str | None = None,
+        mfa: bool = False,
     ) -> str:
         """
         Update the email address of an end user, after verifying the authenticity of the end user using OTP.
@@ -178,6 +179,9 @@ class OTP(AuthBase):
         login_id (str): The login ID of the user whose information is being updated
         email (str): The new email address. If an email address already exists for this end user, it will be overwritten
         refresh_token (str): The session's refresh token (used for verification)
+        mfa (bool): Defaults to false. When true, the auth methods already on the refresh token are preserved and
+            the updated factor is added to them (so the resulting amr keeps the previously-passed factors) instead
+            of replacing it with a single factor. Requires a valid refresh token.
 
         Raise:
         AuthException: raised if OTP verification fails or if token verification fails
@@ -197,6 +201,7 @@ class OTP(AuthBase):
             template_options,
             template_id,
             provider_id,
+            mfa,
         )
         response = self._http.post(uri, body=body, pswd=refresh_token)
         return Auth.extract_masked_address(response.json(), DeliveryMethod.EMAIL)
@@ -212,6 +217,7 @@ class OTP(AuthBase):
         template_options: dict | None = None,
         template_id: str | None = None,
         provider_id: str | None = None,
+        mfa: bool = False,
     ) -> str:
         """
         Update the phone number of an existing end user, after verifying the authenticity of the end user using OTP.
@@ -224,6 +230,9 @@ class OTP(AuthBase):
         add_to_login_ids (bool): Defaults to false, determine whether to add this email to the login ids of hte user or not
         on_merge_use_existing (bool): Defaults to false, In case add_to_login_ids and there is such a user already
             determine whether keep the existing user, or this new one
+        mfa (bool): Defaults to false. When true, the auth methods already on the refresh token are preserved and
+            the updated factor is added to them (so the resulting amr keeps the previously-passed factors) instead
+            of replacing it with a single factor. Requires a valid refresh token.
 
         Raise:
         AuthException: raised if OTP verification fails or if token verification fails
@@ -243,6 +252,7 @@ class OTP(AuthBase):
             template_options,
             template_id,
             provider_id,
+            mfa,
         )
         response = self._http.post(uri, body=body, pswd=refresh_token)
         return Auth.extract_masked_address(response.json(), method)
@@ -305,6 +315,7 @@ class OTP(AuthBase):
         template_options: dict | None = None,
         template_id: str | None = None,
         provider_id: str | None = None,
+        mfa: bool = False,
     ) -> dict:
         body: dict[str, str | bool | dict] = {
             "loginId": login_id,
@@ -318,6 +329,8 @@ class OTP(AuthBase):
             body["templateId"] = template_id
         if provider_id is not None:
             body["providerId"] = provider_id
+        if mfa:
+            body["mfa"] = mfa
 
         return body
 
@@ -330,6 +343,7 @@ class OTP(AuthBase):
         template_options: dict | None = None,
         template_id: str | None = None,
         provider_id: str | None = None,
+        mfa: bool = False,
     ) -> dict:
         body: dict[str, str | bool | dict] = {
             "loginId": login_id,
@@ -343,5 +357,7 @@ class OTP(AuthBase):
             body["templateId"] = template_id
         if provider_id is not None:
             body["providerId"] = provider_id
+        if mfa:
+            body["mfa"] = mfa
 
         return body

--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -112,6 +112,17 @@ class TestOTP(common.DescopeTest):
                 "onMergeUseExisting": True,
             },
         )
+        # mfa flag is included only when set
+        self.assertEqual(
+            OTP._compose_update_user_phone_body("dummy@dummy.com", "+11111111", False, False, mfa=True),
+            {
+                "loginId": "dummy@dummy.com",
+                "phone": "+11111111",
+                "addToLoginIDs": False,
+                "onMergeUseExisting": False,
+                "mfa": True,
+            },
+        )
 
     def test_compose_update_user_email_body(self):
         self.assertEqual(
@@ -121,6 +132,17 @@ class TestOTP(common.DescopeTest):
                 "email": "dummy@dummy.com",
                 "addToLoginIDs": False,
                 "onMergeUseExisting": True,
+            },
+        )
+        # mfa flag is included only when set
+        self.assertEqual(
+            OTP._compose_update_user_email_body("dummy@dummy.com", "dummy@dummy.com", False, False, mfa=True),
+            {
+                "loginId": "dummy@dummy.com",
+                "email": "dummy@dummy.com",
+                "addToLoginIDs": False,
+                "onMergeUseExisting": False,
+                "mfa": True,
             },
         )
 
@@ -785,6 +807,42 @@ class TestOTP(common.DescopeTest):
                     "addToLoginIDs": False,
                     "onMergeUseExisting": False,
                     "templateOptions": {"bla": "blue"},
+                },
+                follow_redirects=False,
+                verify=SSLMatcher(),
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+                params=None,
+            )
+
+        # Test success flow with mfa
+        with patch("httpx.post") as mock_post:
+            my_mock_response = mock.Mock()
+            my_mock_response.is_success = True
+            my_mock_response.json.return_value = {"maskedPhone": "*****111"}
+            mock_post.return_value = my_mock_response
+            self.assertEqual(
+                "*****111",
+                client.otp.update_user_phone(
+                    DeliveryMethod.SMS,
+                    "id1",
+                    "+1111111",
+                    "refresh_token1",
+                    mfa=True,
+                ),
+            )
+            mock_post.assert_called_with(
+                f"{common.DEFAULT_BASE_URL}{EndpointsV1.update_user_phone_otp_path}/sms",
+                headers={
+                    **common.default_headers,
+                    "Authorization": f"Bearer {self.dummy_project_id}:refresh_token1",
+                    "x-descope-project-id": self.dummy_project_id,
+                },
+                json={
+                    "loginId": "id1",
+                    "phone": "+1111111",
+                    "addToLoginIDs": False,
+                    "onMergeUseExisting": False,
+                    "mfa": True,
                 },
                 follow_redirects=False,
                 verify=SSLMatcher(),


### PR DESCRIPTION
## What

Adds an `mfa` parameter to the OTP **update phone / email** methods:

```python
client.otp.update_user_phone(DeliveryMethod.SMS, login_id, phone, refresh_token, mfa=True)
client.otp.update_user_email(login_id, email, refresh_token, mfa=True)
```

## Why

When an already-authenticated user enrolls or updates a phone/email via the OTP update flow, verification mints a fresh **single-factor** session token, dropping the auth methods already on the refresh token (e.g. `pwd`). This forced a double-confirmation UX (one round to enroll the factor, a second `mfa` sign-in just to re-grab a token with a correct merged `amr`).

With `mfa=True` (and a valid refresh token), the resulting session token preserves the prior factors and adds the updated one, e.g. `['pwd', 'phone', 'mfa']`.

Reported by PerciHealth (descope/etc#16372). Pairs with the backend change adding `mfa` to `UpdateUserPhoneOTPRequest` / `UpdateUserEmailOTPRequest`.

## Notes

- `mfa` defaults to `False` and is only added to the request body when truthy, so existing callers are unaffected.
- Applies to the OTP update flows only (matching backend support).

## Test

Extended `test_compose_update_user_phone_body` / `test_compose_update_user_email_body` to cover the `mfa` body field, and added an `mfa=True` HTTP-level case to `test_update_user_phone`. `tests/test_otp.py` passes (12 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)