### PR TITLE
feat(http): also retry on transient status code 520

### DIFF
--- a/descope/http_client.py
+++ b/descope/http_client.py
@@ -33,7 +33,7 @@ def sdk_version():
 
 
 # HTTP status codes that should trigger automatic retries
-_RETRY_STATUS_CODES = {503, 521, 522, 524, 530}
+_RETRY_STATUS_CODES = {503, 520, 521, 522, 524, 530}
 # Delays in seconds between retries: first retry after 100ms, subsequent retries after 5s
 _RETRY_DELAYS_SECONDS = [0.1, 5.0, 5.0]
 

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -512,8 +512,8 @@ class TestRetryMechanism(unittest.TestCase):
     @patch("time.sleep")
     @patch("httpx.get")
     def test_retries_on_retryable_codes(self, mock_get, mock_sleep):
-        """Test that all retryable status codes (503, 521, 522, 524, 530) trigger a retry."""
-        for status_code in [503, 521, 522, 524, 530]:
+        """Test that all retryable status codes (503, 520, 521, 522, 524, 530) trigger a retry."""
+        for status_code in [503, 520, 521, 522, 524, 530]:
             mock_get.reset_mock()
             mock_sleep.reset_mock()
 


### PR DESCRIPTION
## Summary

Add Cloudflare status code `520` ("Web Server Returned an Unknown Error") to the set of transient HTTP status codes that trigger an automatic retry, alongside the existing `503` / `521` / `522` / `524` / `530`.

Like the other Cloudflare 52x codes already in the list, `520` is a transient edge error returned when the origin is briefly unreachable (e.g. during pod replacement on deploy), so the request is safe to retry.

Follow-up to #792.

https://github.com/descope/etc/issues/14039

## Test plan

- [x] `test_retries_on_retryable_codes` updated to include `520` — passes
- [x] Retry suite passes (`pytest tests/test_http_client.py -k retry` → 14 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)