### PR TITLE
ci: make All Checks Passed gate fail instead of skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     needs: [validate-pr-title, lint, build, coverage, gitleaks]
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+    # Must run unconditionally so this required status check always reports a
+    # real conclusion. If it were skipped (e.g. via an `if` that drops out when
+    # a dependency fails), branch protection would treat the skip as a pass.
+    if: always()
     steps:
+      - name: Fail if any dependency failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
       - name: Yey, all checks passed!
         run: echo "All checks passed! :tada:"


### PR DESCRIPTION
The required status check `All Checks Passed` (job `done`) used an `if`
condition that evaluated false whenever a dependency failed, causing the
job to be skipped. Branch protection treats a skipped required check as
satisfied, so failing PRs could merge (e.g. #1584).

Run the job unconditionally and explicitly exit 1 when any dependency
fails or is cancelled, so the gate reports a real failure conclusion.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MZttWkoiN7iRQqRSzyDM77