### PR TITLE
fix(mgmt): support template_id and template_options in invite_batch

### DIFF
--- a/descope/management/_user_base.py
+++ b/descope/management/_user_base.py
@@ -136,6 +136,8 @@ class UserBase:
         send_mail: Optional[bool],
         send_sms: Optional[bool],
         locale: Optional[str] = None,
+        template_options: Optional[dict] = None,
+        template_id: str = "",
     ) -> dict:
         users_body = []
         for user in users:
@@ -178,6 +180,10 @@ class UserBase:
             body["sendMail"] = send_mail
         if send_sms is not None:
             body["sendSMS"] = send_sms
+        if template_options is not None:
+            body["templateOptions"] = template_options
+        if template_id != "":
+            body["templateId"] = template_id
         if locale is not None:
             body["locale"] = locale
         return body

--- a/descope/management/user.py
+++ b/descope/management/user.py
@@ -236,6 +236,8 @@ class User(UserBase, HTTPBase):
         send_mail: Optional[bool] = None,  # send invite via mail, default is according to project settings
         send_sms: Optional[bool] = None,  # send invite via text message, default is according to project settings
         locale: Optional[str] = None,  # locale for the invite message
+        template_options: Optional[dict] = None,  # for providing messaging template options
+        template_id: str = "",  # for overriding the default messaging template
     ) -> dict:
         """
         Create users in batch and invite them via an email / text message.
@@ -257,6 +259,8 @@ class User(UserBase, HTTPBase):
                 send_mail,
                 send_sms,
                 locale,
+                template_options=template_options,
+                template_id=template_id,
             ),
         )
         return response.json()

--- a/descope/management/user_async.py
+++ b/descope/management/user_async.py
@@ -240,6 +240,8 @@ class UserAsync(UserBase, AsyncHTTPBase):
         send_mail: Optional[bool] = None,  # send invite via mail, default is according to project settings
         send_sms: Optional[bool] = None,  # send invite via text message, default is according to project settings
         locale: Optional[str] = None,  # locale for the invite message
+        template_options: Optional[dict] = None,  # for providing messaging template options
+        template_id: str = "",  # for overriding the default messaging template
     ) -> dict:
         """
         Create users in batch and invite them via an email / text message.
@@ -261,6 +263,8 @@ class UserAsync(UserBase, AsyncHTTPBase):
                 send_mail,
                 send_sms,
                 locale,
+                template_options=template_options,
+                template_id=template_id,
             ),
         )
         return response.json()

--- a/tests/management/test_user.py
+++ b/tests/management/test_user.py
@@ -284,6 +284,8 @@ class TestUser:
                     invite_url="invite.me",
                     send_sms=True,
                     locale="en",
+                    template_options={"k1": "v1"},
+                    template_id="tmpl-1",
                 )
             )
             users = resp["users"]
@@ -326,6 +328,8 @@ class TestUser:
                 "invite": True,
                 "inviteUrl": "invite.me",
                 "sendSMS": True,
+                "templateOptions": {"k1": "v1"},
+                "templateId": "tmpl-1",
                 "locale": "en",
             }
             assert_http_called(
@@ -368,6 +372,8 @@ class TestUser:
                 )
             )
 
+            del expected_users["templateOptions"]
+            del expected_users["templateId"]
             del expected_users["users"][0]["hashedPassword"]
             expected_users["users"][0]["password"] = "clear"
             assert_http_called(


### PR DESCRIPTION
## Summary

`invite_batch` (sync and async) had no way to select a messaging template - the batch create request body never included `templateId` or `templateOptions`, so batch invitations always used the project default template. The single-user `invite` already supports `template_id`, and the backend batch endpoint (`POST /v1/mgmt/user/create/batch`) already supports both fields - this was purely an SDK gap.

Counterpart of descope/go-sdk#797.

## Changes

- `UserBase._compose_create_batch_body`: accept and serialize `template_options` / `template_id`
- `User.invite_batch` + `UserAsync.invite_batch`: new optional `template_options` and `template_id` params (appended after existing params, no positional break)
- Extend `test_invite_batch` to assert both fields are sent

## Testing

- `pytest tests/management/test_user.py` - 128 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)