### PR TITLE
feat: document external-group source on group listing responses

### DIFF
--- a/descope/management/group.py
+++ b/descope/management/group.py
@@ -21,6 +21,7 @@ class Group(HTTPBase):
                 {
                     "id": <group id>,
                     "display": <display name>,
+                    "source": <"scim" or "jit">,
                     "members":[
                         {
                             "loginId": <loginId>,
@@ -63,6 +64,7 @@ class Group(HTTPBase):
                 {
                     "id": <group id>,
                     "display": <display name>,
+                    "source": <"scim" or "jit">,
                     "members":[
                         {
                             "loginId": <loginId>,
@@ -108,6 +110,7 @@ class Group(HTTPBase):
                 {
                     "id": <group id>,
                     "display": <display name>,
+                    "source": <"scim" or "jit">,
                     "members":[
                         {
                             "loginId": <loginId>,

--- a/descope/management/group_async.py
+++ b/descope/management/group_async.py
@@ -25,6 +25,7 @@ class GroupAsync(AsyncHTTPBase):
                 {
                     "id": <group id>,
                     "display": <display name>,
+                    "source": <"scim" or "jit">,
                     "members":[
                         {
                             "loginId": <loginId>,
@@ -67,6 +68,7 @@ class GroupAsync(AsyncHTTPBase):
                 {
                     "id": <group id>,
                     "display": <display name>,
+                    "source": <"scim" or "jit">,
                     "members":[
                         {
                             "loginId": <loginId>,
@@ -112,6 +114,7 @@ class GroupAsync(AsyncHTTPBase):
                 {
                     "id": <group id>,
                     "display": <display name>,
+                    "source": <"scim" or "jit">,
                     "members":[
                         {
                             "loginId": <loginId>,


### PR DESCRIPTION
## What

Group listing responses (`load_all_groups` / `load_all_groups_for_members` / `load_all_group_members`, sync and async) now carry a `source` field (`"scim"` | `"jit"`) distinguishing SCIM-provisioned groups from JIT (SSO SAML/OIDC assertion) groups. Responses are dicts, so the field passes through automatically — this documents it in the response shape.

## Why

Backend now persists JIT (SSO assertion) groups as external groups so the `{{user.idpGroups}}` claim survives token refresh, and the management group API exposes their origin via a new `source` field. This mirrors the equivalent go-sdk / node-sdk changes so all SDKs surface it.

## Related

- go-sdk: `feat/external-group-source` (Group.Source)
- node-sdk: descope/node-sdk#770
- backend: descope/backend#1776

🤖 Generated with [Claude Code](https://claude.com/claude-code)