### PR TITLE
feat: add remove_recovery_codes user management method

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,14 @@ Pass the loginId to the function to remove the user's TOTP seed.
 response = descope_client.mgmt.user.remove_totp_seed(login_id=login_id)
 ```
 
+#### Deleting Recovery Codes
+
+Pass the loginId to the function to revoke all of the user's recovery codes.
+
+```python
+response = descope_client.mgmt.user.remove_recovery_codes(login_id=login_id)
+```
+
 ### Passwords
 
 The user can also authenticate with a password, though it's recommended to

--- a/descope/management/common.py
+++ b/descope/management/common.py
@@ -177,6 +177,7 @@ class MgmtV1:
     user_expire_password_path = "/v1/mgmt/user/password/expire"
     user_remove_all_passkeys_path = "/v1/mgmt/user/passkeys/delete"
     user_remove_totp_seed_path = "/v1/mgmt/user/totp/delete"
+    user_remove_recovery_codes_path = "/v1/mgmt/user/recovery-codes/delete"
     user_add_tenant_path = "/v1/mgmt/user/update/tenant/add"
     user_remove_tenant_path = "/v1/mgmt/user/update/tenant/remove"
     user_generate_otp_for_test_path = "/v1/mgmt/tests/generate/otp"

--- a/descope/management/user.py
+++ b/descope/management/user.py
@@ -1580,6 +1580,25 @@ class User(UserBase, HTTPBase):
         )
         return
 
+    def remove_recovery_codes(
+        self,
+        login_id: str,
+    ) -> None:
+        """
+            Removes all recovery codes for the user with the given login ID.
+
+        Args:
+        login_id (str): The login ID of the user to remove recovery codes for.
+
+        Raise:
+        AuthException: raised if the operation fails
+        """
+        self._http.post(
+            MgmtV1.user_remove_recovery_codes_path,
+            body={"loginId": login_id},
+        )
+        return
+
     def generate_otp_for_test_user(
         self,
         method: DeliveryMethod,

--- a/descope/management/user_async.py
+++ b/descope/management/user_async.py
@@ -1586,6 +1586,25 @@ class UserAsync(UserBase, AsyncHTTPBase):
         )
         return
 
+    async def remove_recovery_codes(
+        self,
+        login_id: str,
+    ) -> None:
+        """
+            Removes all recovery codes for the user with the given login ID.
+
+        Args:
+        login_id (str): The login ID of the user to remove recovery codes for.
+
+        Raise:
+        AuthException: raised if the operation fails
+        """
+        await self._http.post(
+            MgmtV1.user_remove_recovery_codes_path,
+            body={"loginId": login_id},
+        )
+        return
+
     async def generate_otp_for_test_user(
         self,
         method: DeliveryMethod,

--- a/tests/management/test_user.py
+++ b/tests/management/test_user.py
@@ -2239,6 +2239,37 @@ class TestUser:
                 follow_redirects=False,
             )
 
+    async def test_user_remove_recovery_codes(self, client_factory):
+        client = client_factory.make(PROJECT_ID, PUBLIC_KEY_DICT, False, "key")
+
+        # Test failed flows
+        with client.mock_mgmt_post(make_response(status=500)) as mock_post:
+            with pytest.raises(AuthException):
+                await client.invoke(client.mgmt.user.remove_recovery_codes("login-id"))
+
+        # Test success flow
+        with client.mock_mgmt_post(make_response({})) as mock_post:
+            await client.invoke(
+                client.mgmt.user.remove_recovery_codes(
+                    "login-id",
+                )
+            )
+            assert_http_called(
+                mock_post,
+                client.mode,
+                f"{DEFAULT_BASE_URL}{MgmtV1.user_remove_recovery_codes_path}",
+                headers={
+                    **default_headers,
+                    "Authorization": f"Bearer {PROJECT_ID}:key",
+                    "x-descope-project-id": PROJECT_ID,
+                },
+                params=None,
+                json={
+                    "loginId": "login-id",
+                },
+                follow_redirects=False,
+            )
+
     async def test_generate_magic_link_for_test_user(self, client_factory):
         client = client_factory.make(PROJECT_ID, PUBLIC_KEY_DICT, False, "key")
 


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/17502

## Related PRs
### Related PRs
- https://github.com/descope/backend/pull/2092
- https://github.com/descope/go-sdk/pull/818
- https://github.com/descope/node-sdk/pull/784

## In a Nutshell
- Add `remove_recovery_codes` user management method (sync + async)

## Description
Adds the SDK wrapper for the new backend endpoint `POST /v1/mgmt/user/recovery-codes/delete` (descope/backend#2092), which revokes all of a user's recovery codes. Mirrors the existing `remove_totp_seed` method.

## Must
- [x] Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

