### PR TITLE
docs: remove_recovery_codes accepts login ID or user ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ response = descope_client.mgmt.user.remove_totp_seed(login_id=login_id)
 
 #### Deleting Recovery Codes
 
-Pass the loginId to the function to revoke all of the user's recovery codes.
+Pass the user's login ID or user ID to the function to revoke all of the user's recovery codes.
 
 ```python
 response = descope_client.mgmt.user.remove_recovery_codes(login_id=login_id)

--- a/descope/management/user.py
+++ b/descope/management/user.py
@@ -1585,10 +1585,10 @@ class User(UserBase, HTTPBase):
         login_id: str,
     ) -> None:
         """
-            Removes all recovery codes for the user with the given login ID.
+            Removes all recovery codes for the user with the given login ID or user ID.
 
         Args:
-        login_id (str): The login ID of the user to remove recovery codes for.
+        login_id (str): The login ID or user ID of the user to remove recovery codes for.
 
         Raise:
         AuthException: raised if the operation fails

--- a/descope/management/user_async.py
+++ b/descope/management/user_async.py
@@ -1591,10 +1591,10 @@ class UserAsync(UserBase, AsyncHTTPBase):
         login_id: str,
     ) -> None:
         """
-            Removes all recovery codes for the user with the given login ID.
+            Removes all recovery codes for the user with the given login ID or user ID.
 
         Args:
-        login_id (str): The login ID of the user to remove recovery codes for.
+        login_id (str): The login ID or user ID of the user to remove recovery codes for.
 
         Raise:
         AuthException: raised if the operation fails


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/17502

## Related PRs
### Related PRs
- https://github.com/descope/backend/pull/2092
- https://github.com/descope/python-sdk/pull/1643

## In a Nutshell
- Document that `remove_recovery_codes` accepts a login ID or user ID

## Description
Follow-up to #1643: the backend resolves the identifier as either a login ID or a user ID (descope/backend#2092), and the public API field is named `identifier` like the other user endpoints. Docstring/README update only — the `login_id` keyword argument is kept for backward compatibility, matching the SDK's convention for dual-ID endpoints (`delete`, `update`).

## Must
- [x] Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)