### PR TITLE
fix(role): send roleNames on batch delete instead of an ignored roles array

### DIFF
--- a/README.md
+++ b/README.md
@@ -1110,8 +1110,16 @@ descope_client.mgmt.role.update_batch(
 
 # Delete a batch of roles in a single atomic transaction. This action is irreversible. Use carefully.
 descope_client.mgmt.role.delete_batch(
-    role_names=["Role 1", "Role 2"],
+    roles=["Role 1", "Role 2"],
     tenant_id="<tenant_id>",  # Optional, the tenant the roles belong to
+)
+
+# Role objects are also accepted, as long as they all belong to the same tenant.
+descope_client.mgmt.role.delete_batch(
+    roles=[
+        {"name": "Role 1"},
+        {"name": "Role 2", "tenantId": "<tenant_id>"},
+    ]
 )
 
 # Roles can also be deleted in a batch by their IDs.

--- a/README.md
+++ b/README.md
@@ -1110,10 +1110,14 @@ descope_client.mgmt.role.update_batch(
 
 # Delete a batch of roles in a single atomic transaction. This action is irreversible. Use carefully.
 descope_client.mgmt.role.delete_batch(
-    roles=[
-        {"name": "Role 1"},
-        {"name": "Role 2", "tenantId": "<tenant_id>"},
-    ]
+    role_names=["Role 1", "Role 2"],
+    tenant_id="<tenant_id>",  # Optional, the tenant the roles belong to
+)
+
+# Roles can also be deleted in a batch by their IDs.
+descope_client.mgmt.role.delete_batch_by_ids(
+    role_ids=["<role_id_1>", "<role_id_2>"],
+    tenant_id="<tenant_id>",  # Optional, the tenant the roles belong to
 )
 
 # Role deletion cannot be undone. Use carefully.

--- a/descope/management/common.py
+++ b/descope/management/common.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 
 class SessionExpirationUnit(Enum):
@@ -85,6 +85,42 @@ def url_params_to_dict(url_params: Optional[List[URLParam]] = None) -> list:
     if url_params is None:
         return []
     return [param.to_dict() for param in url_params]
+
+
+def role_delete_batch_body(
+    roles: List[Union[str, dict]],
+    tenant_id: Optional[str] = None,
+) -> dict:
+    """
+    Build the request body for the role batch delete endpoint.
+
+    Accepts role names, or role objects with a "name" key and an optional
+    "tenantId", and returns the roleNames/tenantId body the endpoint filters on.
+    An empty list is rejected: the endpoint deletes every role when it receives
+    no filter.
+    """
+    if not roles:
+        raise ValueError("roles list cannot be empty")
+
+    role_names: List[str] = []
+    tenant_ids = set()
+    for role in roles:
+        if isinstance(role, str):
+            role_names.append(role)
+        elif isinstance(role, dict) and isinstance(role.get("name"), str):
+            role_names.append(role["name"])
+            if role.get("tenantId") is not None:
+                tenant_ids.add(role["tenantId"])
+        else:
+            raise ValueError('roles must be role names or dicts with a "name" key')
+
+    if tenant_id is not None:
+        tenant_ids.add(tenant_id)
+
+    if len(tenant_ids) > 1:
+        raise ValueError("all roles in a batch delete must belong to the same tenant")
+
+    return {"roleNames": role_names, "tenantId": next(iter(tenant_ids), None)}
 
 
 class MgmtV1:

--- a/descope/management/role.py
+++ b/descope/management/role.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from descope._http_base import HTTPBase
-from descope.management.common import MgmtV1
+from descope.management.common import MgmtV1, role_delete_batch_body
 
 
 class Role(HTTPBase):
@@ -95,33 +95,27 @@ class Role(HTTPBase):
 
     def delete_batch(
         self,
-        role_names: List[str],
+        roles: List[Union[str, dict]],
         tenant_id: Optional[str] = None,
     ):
         """
-        Delete a batch of roles by name in a single atomic transaction.
+        Delete a batch of roles in a single atomic transaction.
         IMPORTANT: This action is irreversible. Use carefully.
 
         Args:
-        role_names (List[str]): List of role names to delete.
+        roles (List[Union[str, dict]]): List of role names to delete, or role objects each with:
+            - name (str): role name.
+            - tenantId (str): Optional tenant ID.
         tenant_id (str): Optional tenant ID the roles belong to.
 
         Raise:
-        ValueError: raised if role_names is empty or is not a list of names
+        ValueError: raised if roles is empty, holds an entry without a name,
+            or spans more than one tenant
         AuthException: raised if deletion operation fails
         """
-        if not role_names:
-            raise ValueError("role_names list cannot be empty")
-
-        if any(not isinstance(name, str) for name in role_names):
-            raise ValueError(
-                'role_names must be a list of role names, e.g. ["Role 1", "Role 2"]. '
-                "To delete by role ID use delete_batch_by_ids."
-            )
-
         self._http.post(
             MgmtV1.role_delete_batch_path,
-            body={"roleNames": role_names, "tenantId": tenant_id},
+            body=role_delete_batch_body(roles, tenant_id),
         )
 
     def delete_batch_by_ids(

--- a/descope/management/role.py
+++ b/descope/management/role.py
@@ -95,23 +95,33 @@ class Role(HTTPBase):
 
     def delete_batch(
         self,
-        roles: List[dict],
+        role_names: List[str],
+        tenant_id: Optional[str] = None,
     ):
         """
-        Delete a batch of roles in a single atomic transaction.
+        Delete a batch of roles by name in a single atomic transaction.
         IMPORTANT: This action is irreversible. Use carefully.
 
         Args:
-        roles (List[dict]): List of role objects to delete, each with:
-            - name (str): role name.
-            - tenantId (str): Optional tenant ID.
+        role_names (List[str]): List of role names to delete.
+        tenant_id (str): Optional tenant ID the roles belong to.
 
         Raise:
+        ValueError: raised if role_names is empty or is not a list of names
         AuthException: raised if deletion operation fails
         """
+        if not role_names:
+            raise ValueError("role_names list cannot be empty")
+
+        if any(not isinstance(name, str) for name in role_names):
+            raise ValueError(
+                'role_names must be a list of role names, e.g. ["Role 1", "Role 2"]. '
+                "To delete by role ID use delete_batch_by_ids."
+            )
+
         self._http.post(
             MgmtV1.role_delete_batch_path,
-            body={"roles": roles},
+            body={"roleNames": role_names, "tenantId": tenant_id},
         )
 
     def delete_batch_by_ids(
@@ -128,8 +138,12 @@ class Role(HTTPBase):
         tenant_id (str): Optional tenant ID the roles belong to.
 
         Raise:
+        ValueError: raised if role_ids is empty
         AuthException: raised if deletion operation fails
         """
+        if not role_ids:
+            raise ValueError("role_ids list cannot be empty")
+
         self._http.post(
             MgmtV1.role_delete_batch_path,
             body={"roleIds": role_ids, "tenantId": tenant_id},

--- a/descope/management/role_async.py
+++ b/descope/management/role_async.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from descope._http_base import AsyncHTTPBase
-from descope.management.common import MgmtV1
+from descope.management.common import MgmtV1, role_delete_batch_body
 
 
 class RoleAsync(AsyncHTTPBase):
@@ -97,33 +97,27 @@ class RoleAsync(AsyncHTTPBase):
 
     async def delete_batch(
         self,
-        role_names: List[str],
+        roles: List[Union[str, dict]],
         tenant_id: Optional[str] = None,
     ):
         """
-        Delete a batch of roles by name in a single atomic transaction.
+        Delete a batch of roles in a single atomic transaction.
         IMPORTANT: This action is irreversible. Use carefully.
 
         Args:
-        role_names (List[str]): List of role names to delete.
+        roles (List[Union[str, dict]]): List of role names to delete, or role objects each with:
+            - name (str): role name.
+            - tenantId (str): Optional tenant ID.
         tenant_id (str): Optional tenant ID the roles belong to.
 
         Raise:
-        ValueError: raised if role_names is empty or is not a list of names
+        ValueError: raised if roles is empty, holds an entry without a name,
+            or spans more than one tenant
         AuthException: raised if deletion operation fails
         """
-        if not role_names:
-            raise ValueError("role_names list cannot be empty")
-
-        if any(not isinstance(name, str) for name in role_names):
-            raise ValueError(
-                'role_names must be a list of role names, e.g. ["Role 1", "Role 2"]. '
-                "To delete by role ID use delete_batch_by_ids."
-            )
-
         await self._http.post(
             MgmtV1.role_delete_batch_path,
-            body={"roleNames": role_names, "tenantId": tenant_id},
+            body=role_delete_batch_body(roles, tenant_id),
         )
 
     async def delete_batch_by_ids(

--- a/descope/management/role_async.py
+++ b/descope/management/role_async.py
@@ -97,23 +97,33 @@ class RoleAsync(AsyncHTTPBase):
 
     async def delete_batch(
         self,
-        roles: List[dict],
+        role_names: List[str],
+        tenant_id: Optional[str] = None,
     ):
         """
-        Delete a batch of roles in a single atomic transaction.
+        Delete a batch of roles by name in a single atomic transaction.
         IMPORTANT: This action is irreversible. Use carefully.
 
         Args:
-        roles (List[dict]): List of role objects to delete, each with:
-            - name (str): role name.
-            - tenantId (str): Optional tenant ID.
+        role_names (List[str]): List of role names to delete.
+        tenant_id (str): Optional tenant ID the roles belong to.
 
         Raise:
+        ValueError: raised if role_names is empty or is not a list of names
         AuthException: raised if deletion operation fails
         """
+        if not role_names:
+            raise ValueError("role_names list cannot be empty")
+
+        if any(not isinstance(name, str) for name in role_names):
+            raise ValueError(
+                'role_names must be a list of role names, e.g. ["Role 1", "Role 2"]. '
+                "To delete by role ID use delete_batch_by_ids."
+            )
+
         await self._http.post(
             MgmtV1.role_delete_batch_path,
-            body={"roles": roles},
+            body={"roleNames": role_names, "tenantId": tenant_id},
         )
 
     async def delete_batch_by_ids(
@@ -130,8 +140,12 @@ class RoleAsync(AsyncHTTPBase):
         tenant_id (str): Optional tenant ID the roles belong to.
 
         Raise:
+        ValueError: raised if role_ids is empty
         AuthException: raised if deletion operation fails
         """
+        if not role_ids:
+            raise ValueError("role_ids list cannot be empty")
+
         await self._http.post(
             MgmtV1.role_delete_batch_path,
             body={"roleIds": role_ids, "tenantId": tenant_id},

--- a/samples/management/role_sample_app.py
+++ b/samples/management/role_sample_app.py
@@ -105,7 +105,7 @@ def main():
             logging.info("Deleting a batch of roles")
             descope_client.mgmt.role.delete_batch(
                 [
-                    {"name": "Updated Batch Role 1"},
+                    "Updated Batch Role 1",
                 ]
             )
 

--- a/tests/management/test_role.py
+++ b/tests/management/test_role.py
@@ -330,21 +330,23 @@ class TestRole:
         # Test failed flow
         with client.mock_mgmt_post(make_response(status=500)) as mock:
             with pytest.raises(AuthException):
+                await client.invoke(client.mgmt.role.delete_batch(["R1"]))
+
+        # An empty list would delete every role in the project, so it is rejected
+        with client.mock_mgmt_post(make_response()) as mock:
+            with pytest.raises(ValueError):
+                await client.invoke(client.mgmt.role.delete_batch([]))
+            mock.assert_not_called()
+
+        # The pre-fix signature took role objects, which never filtered the deletion
+        with client.mock_mgmt_post(make_response()) as mock:
+            with pytest.raises(ValueError):
                 await client.invoke(client.mgmt.role.delete_batch([{"name": "R1"}]))
+            mock.assert_not_called()
 
         # Test success flow
         with client.mock_mgmt_post(make_response()) as mock:
-            assert (
-                await client.invoke(
-                    client.mgmt.role.delete_batch(
-                        [
-                            {"name": "R1", "tenantId": "t1"},
-                            {"name": "R2"},
-                        ]
-                    )
-                )
-                is None
-            )
+            assert await client.invoke(client.mgmt.role.delete_batch(["R1", "R2"], "t1")) is None
             assert_http_called(
                 mock,
                 client.mode,
@@ -355,12 +357,24 @@ class TestRole:
                     "x-descope-project-id": PROJECT_ID,
                 },
                 params=None,
-                json={
-                    "roles": [
-                        {"name": "R1", "tenantId": "t1"},
-                        {"name": "R2"},
-                    ]
+                json={"roleNames": ["R1", "R2"], "tenantId": "t1"},
+                follow_redirects=False,
+            )
+
+        # Test success flow without a tenant
+        with client.mock_mgmt_post(make_response()) as mock:
+            assert await client.invoke(client.mgmt.role.delete_batch(["R1"])) is None
+            assert_http_called(
+                mock,
+                client.mode,
+                f"{DEFAULT_BASE_URL}{MgmtV1.role_delete_batch_path}",
+                headers={
+                    **default_headers,
+                    "Authorization": f"Bearer {PROJECT_ID}:key",
+                    "x-descope-project-id": PROJECT_ID,
                 },
+                params=None,
+                json={"roleNames": ["R1"], "tenantId": None},
                 follow_redirects=False,
             )
 
@@ -371,6 +385,12 @@ class TestRole:
         with client.mock_mgmt_post(make_response(status=500)) as mock:
             with pytest.raises(AuthException):
                 await client.invoke(client.mgmt.role.delete_batch_by_ids(["ROL1"]))
+
+        # An empty list would delete every role in the project, so it is rejected
+        with client.mock_mgmt_post(make_response()) as mock:
+            with pytest.raises(ValueError):
+                await client.invoke(client.mgmt.role.delete_batch_by_ids([]))
+            mock.assert_not_called()
 
         # Test success flow
         with client.mock_mgmt_post(make_response()) as mock:

--- a/tests/management/test_role.py
+++ b/tests/management/test_role.py
@@ -338,13 +338,26 @@ class TestRole:
                 await client.invoke(client.mgmt.role.delete_batch([]))
             mock.assert_not_called()
 
-        # The pre-fix signature took role objects, which never filtered the deletion
+        # Entries without a name would silently drop out of the filter
         with client.mock_mgmt_post(make_response()) as mock:
             with pytest.raises(ValueError):
-                await client.invoke(client.mgmt.role.delete_batch([{"name": "R1"}]))
+                await client.invoke(client.mgmt.role.delete_batch([{"id": "ROL1"}]))
             mock.assert_not_called()
 
-        # Test success flow
+        # The endpoint takes a single tenant, so a batch spanning tenants is rejected
+        with client.mock_mgmt_post(make_response()) as mock:
+            with pytest.raises(ValueError):
+                await client.invoke(
+                    client.mgmt.role.delete_batch(
+                        [
+                            {"name": "R1", "tenantId": "t1"},
+                            {"name": "R2", "tenantId": "t2"},
+                        ]
+                    )
+                )
+            mock.assert_not_called()
+
+        # Test success flow with role names
         with client.mock_mgmt_post(make_response()) as mock:
             assert await client.invoke(client.mgmt.role.delete_batch(["R1", "R2"], "t1")) is None
             assert_http_called(
@@ -375,6 +388,33 @@ class TestRole:
                 },
                 params=None,
                 json={"roleNames": ["R1"], "tenantId": None},
+                follow_redirects=False,
+            )
+
+        # Test success flow with role objects, the shape accepted before the fix
+        with client.mock_mgmt_post(make_response()) as mock:
+            assert (
+                await client.invoke(
+                    client.mgmt.role.delete_batch(
+                        [
+                            {"name": "R1", "tenantId": "t1"},
+                            {"name": "R2"},
+                        ]
+                    )
+                )
+                is None
+            )
+            assert_http_called(
+                mock,
+                client.mode,
+                f"{DEFAULT_BASE_URL}{MgmtV1.role_delete_batch_path}",
+                headers={
+                    **default_headers,
+                    "Authorization": f"Bearer {PROJECT_ID}:key",
+                    "x-descope-project-id": PROJECT_ID,
+                },
+                params=None,
+                json={"roleNames": ["R1", "R2"], "tenantId": "t1"},
                 follow_redirects=False,
             )
 


### PR DESCRIPTION
## Problem

`role.delete_batch` sends `{"roles": [{"name": "..."}]}` to `/v1/mgmt/role/delete/batch`, but that endpoint filters on `roleNames` / `roleIds`. The `roles` key is not part of the request contract, so it is ignored and the request is sent without a filter.

`delete_batch_by_ids` on the same class already sends `roleIds` correctly — only the delete-by-name path is affected.

## Fix

`delete_batch` keeps its `roles` parameter and now normalizes it into the `roleNames` / `tenantId` body the endpoint filters on. Both argument shapes work:

```python
descope_client.mgmt.role.delete_batch(["Role 1", "Role 2"], tenant_id="<tenant_id>")

descope_client.mgmt.role.delete_batch([
    {"name": "Role 1"},
    {"name": "Role 2", "tenantId": "<tenant_id>"},
])
```

Existing callers keep working unchanged and now send a correctly filtered request, so this is not a breaking change.

Guards, all raising `ValueError` before any request goes out:

- an empty list, which would otherwise be sent unfiltered
- an entry with no `name`, which would silently drop out of the filter
- a batch spanning more than one tenant, since the endpoint takes a single `tenantId`

`delete_batch_by_ids` is unchanged apart from the empty-list guard.

Normalization lives in one helper in `descope/management/common.py`, shared by the sync and async clients so the two cannot drift. README and the role sample app updated.

## Testing

- `tests/management/test_role.py` asserts the request body for role names and for role objects, with and without a tenant, and covers each `ValueError` guard including that no HTTP call is made. Runs against the sync and async clients.
- Full suite passing; `ruff check`, `ruff format --check`, and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)