### PR TITLE
fix: add status field to create_test_user, matching create()

### DIFF
--- a/descope/management/user.py
+++ b/descope/management/user.py
@@ -109,6 +109,7 @@ class User(UserBase, HTTPBase):
         invite_url: Optional[str] = None,
         additional_login_ids: Optional[List[str]] = None,
         sso_app_ids: Optional[List[str]] = None,
+        status: Optional[str] = None,
     ) -> dict:
         """
         Create a new test user.
@@ -127,6 +128,7 @@ class User(UserBase, HTTPBase):
         picture (str): Optional url for user picture
         custom_attributes (dict): Optional, set the different custom attributes values of the keys that were previously configured in Descope console app
         sso_app_ids (List[str]): Optional, list of SSO applications IDs to be associated with the user.
+        status (str): Optional status field. Can be one of: "enabled", "disabled", "invited", "expired".
 
         Return value (dict):
         Return dict in the format
@@ -136,6 +138,7 @@ class User(UserBase, HTTPBase):
         Raise:
         AuthException: raised if create operation fails
         """
+        UserBase._validate_status(status)
         role_names = [] if role_names is None else role_names
         user_tenants = [] if user_tenants is None else user_tenants
 
@@ -162,6 +165,7 @@ class User(UserBase, HTTPBase):
                 None,
                 additional_login_ids,
                 sso_app_ids,
+                status=status,
             ),
         )
         return response.json()

--- a/descope/management/user_async.py
+++ b/descope/management/user_async.py
@@ -113,6 +113,7 @@ class UserAsync(UserBase, AsyncHTTPBase):
         invite_url: Optional[str] = None,
         additional_login_ids: Optional[List[str]] = None,
         sso_app_ids: Optional[List[str]] = None,
+        status: Optional[str] = None,
     ) -> dict:
         """
         Create a new test user.
@@ -131,6 +132,7 @@ class UserAsync(UserBase, AsyncHTTPBase):
         picture (str): Optional url for user picture
         custom_attributes (dict): Optional, set the different custom attributes values of the keys that were previously configured in Descope console app
         sso_app_ids (List[str]): Optional, list of SSO applications IDs to be associated with the user.
+        status (str): Optional status field. Can be one of: "enabled", "disabled", "invited", "expired".
 
         Return value (dict):
         Return dict in the format
@@ -140,6 +142,7 @@ class UserAsync(UserBase, AsyncHTTPBase):
         Raise:
         AuthException: raised if create operation fails
         """
+        UserBase._validate_status(status)
         role_names = [] if role_names is None else role_names
         user_tenants = [] if user_tenants is None else user_tenants
 
@@ -166,6 +169,7 @@ class UserAsync(UserBase, AsyncHTTPBase):
                 None,
                 additional_login_ids,
                 sso_app_ids,
+                status=status,
             ),
         )
         return response.json()

--- a/tests/management/test_user.py
+++ b/tests/management/test_user.py
@@ -142,6 +142,10 @@ class TestUser:
             with pytest.raises(AuthException):
                 await client.invoke(client.mgmt.user.create("valid-id"))
 
+        with pytest.raises(AuthException) as exc_info:
+            await client.invoke(client.mgmt.user.create_test_user("valid-id", status="invalid_status"))
+        assert "Invalid status value: invalid_status" in str(exc_info.value)
+
         # Test success flow
         with client.mock_mgmt_post(make_response({"user": {"id": "u1"}})) as mock_post:
             resp = await client.invoke(
@@ -154,6 +158,7 @@ class TestUser:
                         AssociatedTenant("tenant2", ["role1", "role2"]),
                     ],
                     custom_attributes={"ak": "av"},
+                    status="disabled",
                 )
             )
             user = resp["user"]
@@ -184,6 +189,7 @@ class TestUser:
                     "invite": False,
                     "additionalLoginIds": None,
                     "ssoAppIDs": None,
+                    "status": "disabled",
                 },
                 follow_redirects=False,
             )


### PR DESCRIPTION
## Related Issues

related to https://github.com/descope/python-sdk/pull/1665

## Description

match create_test_user() to create_user() interface

## Must

- [X] Tests
- [ ] Documentation (if applicable)
