### PR TITLE
feat(sso): add configure_auth_type to enable or disable an SSO configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -987,6 +987,14 @@ descope_client.mgmt.sso.configure_oidc_settings(
     domains=["tenant-users.com"] # Users authentication with these domains will be logged in to this tenant
 )
 
+# You can disable an SSO configuration without deleting it, and enable it again later.
+# Its settings, mappings and domains are kept, so re-enabling needs no payload.
+descope_client.mgmt.sso.configure_auth_type(
+    tenant_id, # Which tenant the configuration belongs to
+    "none", # "none" disables it; "saml" or "oidc" enable it on that protocol
+    sso_id="my-sso-id" # Optional, omit for the tenant's default SSO configuration
+)
+
 # DEPRECATED (use load_settings(..) function instead)
 # You can get SSO settings for a tenant
 sso_settings_res = descope_client.mgmt.sso.get_settings("tenant-id")

--- a/descope/management/_sso_settings_base.py
+++ b/descope/management/_sso_settings_base.py
@@ -207,6 +207,20 @@ class SSOSettingsBase:
         }
 
     @staticmethod
+    def _compose_configure_auth_type_body(
+        tenant_id: str,
+        auth_type: str,
+        sso_id: Optional[str],
+    ) -> dict:
+        body: dict = {
+            "tenantId": tenant_id,
+            "authType": auth_type,
+        }
+        if sso_id:
+            body["ssoId"] = sso_id
+        return body
+
+    @staticmethod
     def _compose_configure_xaa_settings_body(
         tenant_id: str,
         settings: XAASettings,

--- a/descope/management/common.py
+++ b/descope/management/common.py
@@ -405,6 +405,7 @@ class MgmtV1:
     sso_redirect_path = "/v1/mgmt/sso/redirect"
     sso_load_all_settings_path = "/v2/mgmt/sso/settings/all"
     sso_new_settings_path = "/v1/mgmt/sso/settings/new"
+    sso_configure_auth_type_path = "/v1/mgmt/sso/settings/authtype"
 
     # tenant revoke sso config link
     tenant_revoke_sso_configuration_link_path = "/v1/mgmt/tenant/adminlinks/sso/revoke"

--- a/descope/management/sso_settings.py
+++ b/descope/management/sso_settings.py
@@ -427,19 +427,25 @@ class SSOSettings(SSOSettingsBase, HTTPBase):
     def delete_settings(
         self,
         tenant_id: str,
+        sso_id: Optional[str] = None,
     ):
         """
         Delete SSO setting for the provided tenant_id.
 
         Args:
         tenant_id (str): The tenant ID of the desired SSO Settings to delete
+        sso_id (str): Optional, the SSO configuration id (for multi-SSO). Omit for the default SSO configuration.
 
         Raise:
         AuthException: raised if delete operation fails
         """
+        params = {"tenantId": tenant_id}
+        if sso_id:
+            params["ssoId"] = sso_id
+
         self._http.delete(
             MgmtV1.sso_settings_path,
-            params={"tenantId": tenant_id},
+            params=params,
         )
 
     def configure_auth_type(

--- a/descope/management/sso_settings.py
+++ b/descope/management/sso_settings.py
@@ -442,6 +442,30 @@ class SSOSettings(SSOSettingsBase, HTTPBase):
             params={"tenantId": tenant_id},
         )
 
+    def configure_auth_type(
+        self,
+        tenant_id: str,
+        auth_type: str,
+        sso_id: Optional[str] = None,
+    ):
+        """
+        Set the authentication type of a single SSO configuration, leaving its stored SAML/OIDC
+        settings, mappings and domains untouched.
+
+        Args:
+        tenant_id (str): The tenant ID the configuration belongs to
+        auth_type (str): "none" disables the configuration without deleting it, "saml" or "oidc"
+            enable it on that protocol with its stored settings, so re-enabling needs no payload.
+        sso_id (str): Optional, the SSO configuration id (for multi-SSO). Omit for the default SSO configuration.
+
+        Raise:
+        AuthException: raised if configuration operation fails
+        """
+        self._http.post(
+            MgmtV1.sso_configure_auth_type_path,
+            body=SSOSettings._compose_configure_auth_type_body(tenant_id, auth_type, sso_id),
+        )
+
     def configure_oidc_settings(
         self,
         tenant_id: str,

--- a/descope/management/sso_settings_async.py
+++ b/descope/management/sso_settings_async.py
@@ -160,19 +160,25 @@ class SSOSettingsAsync(SSOSettingsBase, AsyncHTTPBase):
     async def delete_settings(
         self,
         tenant_id: str,
+        sso_id: Optional[str] = None,
     ):
         """
         Delete SSO setting for the provided tenant_id.
 
         Args:
         tenant_id (str): The tenant ID of the desired SSO Settings to delete
+        sso_id (str): Optional, the SSO configuration id (for multi-SSO). Omit for the default SSO configuration.
 
         Raise:
         AuthException: raised if delete operation fails
         """
+        params = {"tenantId": tenant_id}
+        if sso_id:
+            params["ssoId"] = sso_id
+
         await self._http.delete(
             MgmtV1.sso_settings_path,
-            params={"tenantId": tenant_id},
+            params=params,
         )
 
     async def configure_oidc_settings(

--- a/descope/management/sso_settings_async.py
+++ b/descope/management/sso_settings_async.py
@@ -250,6 +250,30 @@ class SSOSettingsAsync(SSOSettingsBase, AsyncHTTPBase):
             ),
         )
 
+    async def configure_auth_type(
+        self,
+        tenant_id: str,
+        auth_type: str,
+        sso_id: Optional[str] = None,
+    ):
+        """
+        Set the authentication type of a single SSO configuration, leaving its stored SAML/OIDC
+        settings, mappings and domains untouched.
+
+        Args:
+        tenant_id (str): The tenant ID the configuration belongs to
+        auth_type (str): "none" disables the configuration without deleting it, "saml" or "oidc"
+            enable it on that protocol with its stored settings, so re-enabling needs no payload.
+        sso_id (str): Optional, the SSO configuration id (for multi-SSO). Omit for the default SSO configuration.
+
+        Raise:
+        AuthException: raised if configuration operation fails
+        """
+        await self._http.post(
+            MgmtV1.sso_configure_auth_type_path,
+            body=SSOSettingsAsync._compose_configure_auth_type_body(tenant_id, auth_type, sso_id),
+        )
+
     async def configure_xaa_settings(
         self,
         tenant_id: str,

--- a/tests/management/test_sso_settings.py
+++ b/tests/management/test_sso_settings.py
@@ -1343,6 +1343,56 @@ class TestSSOSettings:
                 follow_redirects=True,
             )
 
+    async def test_configure_auth_type(self, client_factory):
+        client = client_factory.make(PROJECT_ID, PUBLIC_KEY_DICT, False, "key")
+
+        # Test failed flow
+        with client.mock_mgmt_post(make_response(status=500)) as mock_post:
+            with pytest.raises(AuthException):
+                await client.invoke(client.mgmt.sso.configure_auth_type("tenant-id", "none"))
+
+        # Test success flow (disable a specific configuration)
+        with client.mock_mgmt_post(make_response()) as mock_post:
+            result = await client.invoke(client.mgmt.sso.configure_auth_type("tenant-id", "none", sso_id="sso-1"))
+            assert result is None
+            assert_http_called(
+                mock_post,
+                client.mode,
+                f"{DEFAULT_BASE_URL}{MgmtV1.sso_configure_auth_type_path}",
+                headers={
+                    **default_headers,
+                    "Authorization": f"Bearer {PROJECT_ID}:key",
+                    "x-descope-project-id": PROJECT_ID,
+                },
+                params=None,
+                json={
+                    "tenantId": "tenant-id",
+                    "authType": "none",
+                    "ssoId": "sso-1",
+                },
+                follow_redirects=False,
+            )
+
+        # Test success flow (the default configuration carries no ssoId)
+        with client.mock_mgmt_post(make_response()) as mock_post:
+            await client.invoke(client.mgmt.sso.configure_auth_type("tenant-id", "saml"))
+            assert_http_called(
+                mock_post,
+                client.mode,
+                f"{DEFAULT_BASE_URL}{MgmtV1.sso_configure_auth_type_path}",
+                headers={
+                    **default_headers,
+                    "Authorization": f"Bearer {PROJECT_ID}:key",
+                    "x-descope-project-id": PROJECT_ID,
+                },
+                params=None,
+                json={
+                    "tenantId": "tenant-id",
+                    "authType": "saml",
+                },
+                follow_redirects=False,
+            )
+
     async def test_new_settings(self, client_factory):
         client = client_factory.make(PROJECT_ID, PUBLIC_KEY_DICT, False, "key")
 

--- a/tests/management/test_sso_settings.py
+++ b/tests/management/test_sso_settings.py
@@ -47,6 +47,23 @@ class TestSSOSettings:
                 follow_redirects=False,
             )
 
+        # Test success flow (a specific SSO configuration of a multi-SSO tenant)
+        with client.mock_mgmt_delete(make_response()) as mock_delete:
+            await client.invoke(client.mgmt.sso.delete_settings("tenant-id", sso_id="conf1"))
+
+            assert_http_called(
+                mock_delete,
+                client.mode,
+                f"{DEFAULT_BASE_URL}{MgmtV1.sso_settings_path}",
+                params={"tenantId": "tenant-id", "ssoId": "conf1"},
+                headers={
+                    **default_headers,
+                    "Authorization": f"Bearer {PROJECT_ID}:key",
+                    "x-descope-project-id": PROJECT_ID,
+                },
+                follow_redirects=False,
+            )
+
     async def test_load_settings(self, client_factory):
         client = client_factory.make(PROJECT_ID, PUBLIC_KEY_DICT, False, "key")
 


### PR DESCRIPTION
## Description

Wraps the new management endpoint `POST /v1/mgmt/sso/settings/authtype` 

```python
# disable one connection of a multi-SSO tenant, keeping its configuration
descope_client.mgmt.sso.configure_auth_type("tenant-id", "none", sso_id="conf1")
# enable it again on the protocol it is configured for
descope_client.mgmt.sso.configure_auth_type("tenant-id", "saml", sso_id="conf1")
# omit sso_id to target the tenant's default configuration
descope_client.mgmt.sso.configure_auth_type("tenant-id", "none")
```

**Why.** A customer running their own admin UI on the management APIs needs to temporarily disable one SSO connection of a multi-SSO tenant. Until now the only per-connection off switch was `delete_settings`, which drops the connection: re-enabling meant `new_settings` plus a full `configure_saml_settings` / `configure_oidc_settings` replay, with the caller storing the mappings, the domains and the OIDC client secret (never returned on read). For SAML it was worse, since a recreated connection gets a new ACS URL and the tenant's IdP admin has to reconfigure. `configure_auth_type` leaves the stored configuration intact, so re-enabling needs no payload.

Body composition sits in `_sso_settings_base.py` with thin sync and async methods, matching `configure_xaa_settings`.

**Second commit — `delete_settings` accepts `sso_id`.** It previously sent only `tenantId`, so it could only delete a tenant's *default* configuration and a multi-SSO tenant's additional configurations were unreachable from this SDK. The node and go SDKs already pass `ssoId` through. Optional keyword, so existing calls are unaffected.

```python
descope_client.mgmt.sso.delete_settings("tenant-id", sso_id="conf1")
```

## Tests

- `test_configure_auth_type` — the failure path, the request body with an `sso_id`, and the default-configuration call that omits it.
- `test_delete_settings` — extended with the specific-configuration case asserting `ssoId` reaches the query params.

Both run in sync and async modes. Full suite: 1084 passed, 26 skipped. `ruff check` and `ruff format --check` clean.
