### PR TITLE
docs(xaa): document the read-only project-level audience on the XAA load response

### DIFF
--- a/descope/management/sso_settings.py
+++ b/descope/management/sso_settings.py
@@ -584,7 +584,10 @@ class SSOSettings(SSOSettingsBase, HTTPBase):
 
         Return value (dict):
         Containing the loaded XAA settings (ssoId, enabled, settings, groupsMapping, defaultSSORoles,
-        fgaMappings, groupsPriority, groupPriorityEnabled, allowOverrideRoles).
+        fgaMappings, groupsPriority, groupPriorityEnabled, allowOverrideRoles, audience).
+        audience is read-only: the project-level audience a requesting application must present in its
+        ID-JAG token. It carries no tenant segment - it equals the issuer the project publishes - so the
+        identity provider must send the tenant id in the token's aud_tenant claim.
 
         Raise:
         AuthException: raised if load operation fails

--- a/descope/management/sso_settings_async.py
+++ b/descope/management/sso_settings_async.py
@@ -316,7 +316,10 @@ class SSOSettingsAsync(SSOSettingsBase, AsyncHTTPBase):
         sso_id (str): Optional, the SSO configuration id (for multi-SSO). Omit for the default SSO configuration.
 
         Return value (dict):
-        Containing the loaded XAA settings.
+        Containing the loaded XAA settings, including the read-only project-level audience a requesting
+        application must present in its ID-JAG token. The audience carries no tenant segment - it equals
+        the issuer the project publishes - so the identity provider must send the tenant id in the
+        token's aud_tenant claim.
 
         Raise:
         AuthException: raised if load operation fails

--- a/tests/management/test_sso_settings.py
+++ b/tests/management/test_sso_settings.py
@@ -482,7 +482,7 @@ class TestSSOSettings:
 
         # Test success flow (with ssoId)
         resp_data = json.loads(
-            """{"ssoId": "sso-1", "enabled": true, "settings": {"issuers": {"https://issuer.example.com": {"jwksUri": "https://issuer.example.com/jwks", "signAlgorithm": "RS256"}}}, "groupsMapping": [{"role": {"id": "r1", "name": "role1"}, "groups": ["g1"]}], "defaultSSORoles": ["aa"], "groupPriorityEnabled": true, "allowOverrideRoles": true}"""
+            """{"ssoId": "sso-1", "enabled": true, "settings": {"issuers": {"https://issuer.example.com": {"jwksUri": "https://issuer.example.com/jwks", "signAlgorithm": "RS256"}}}, "groupsMapping": [{"role": {"id": "r1", "name": "role1"}, "groups": ["g1"]}], "defaultSSORoles": ["aa"], "groupPriorityEnabled": true, "allowOverrideRoles": true, "audience": "https://api.descope.com/v1/apps/P1"}"""
         )
         with client.mock_mgmt_get(make_response(resp_data)) as mock_get:
             resp = await client.invoke(client.mgmt.sso.load_xaa_settings("tenant-id", "sso-1"))
@@ -493,6 +493,8 @@ class TestSSOSettings:
                 == "https://issuer.example.com/jwks"
             )
             assert resp.get("groupsMapping")[0]["role"]["name"] == "role1"
+            # Read-only, project-level: no tenant segment - the tenant travels in the aud_tenant claim.
+            assert resp.get("audience") == "https://api.descope.com/v1/apps/P1"
             assert_http_called(
                 mock_get,
                 client.mode,


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/18013

## Related PRs
### Upstream PRs
- https://github.com/descope/backend/pull/2378

### Related PRs
- https://github.com/descope/console-app/pull/5734
- https://github.com/descope/descope-apps/pull/864
- https://github.com/descope/content/pull/2273
- https://github.com/descope/go-sdk/pull/839
- https://github.com/descope/node-sdk/pull/801
- https://github.com/descope/integrationtests/pull/14790

## In a Nutshell
- Document the read-only `audience` on the XAA load response

## Description
Loading Cross-App Access settings also returns the audience a requesting application has to present in its ID-JAG token, so the docstrings now say so instead of leaving callers to build the value themselves. It has no tenant in it - the identity provider sends the tenant in the token's `aud_tenant` claim.

## Must
- [x] Tests
- [x] Documentation (if applicable)
